### PR TITLE
Display nightly rate with scroll action buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -76,14 +76,24 @@ nav.main-nav {
   right: 0;
   bottom: 0;
   display: flex;
-  justify-content: center;
-  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.75rem 1rem;
   background: var(--color-bg-light);
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
   z-index: 20;
   transform: translateY(100%);
   transition: transform 0.3s ease;
+}
+
+.scroll-buttons .actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.scroll-buttons .price {
+  color: var(--color-primary);
+  font-weight: 600;
 }
 
 .scroll-buttons.visible {

--- a/components/ScrollButtons.tsx
+++ b/components/ScrollButtons.tsx
@@ -39,12 +39,15 @@ export default function ScrollButtons(): ReactElement | null {
 
   return (
     <div className={`scroll-buttons${visible ? ' visible' : ''}`}>
-      <Link href="/properties/#" className="btn">
-        Book
-      </Link>
-      <Link href="/#contact" className="btn outline">
-        Contact
-      </Link>
+      <span className="price">$315/night</span>
+      <div className="actions">
+        <Link href="/properties/#" className="btn">
+          Book
+        </Link>
+        <Link href="/#contact" className="btn outline">
+          Contact
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show `$315/night` price beside book/contact buttons and group buttons for layout
- Style scroll buttons bar to space price and actions and color price with primary blue

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bebe533f2c832886635b8e568c78cf