### PR TITLE
Center sticky price bar on larger screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -72,8 +72,7 @@ nav.main-nav {
 /* Scroll-activated bottom buttons */
 .scroll-buttons {
   position: fixed;
-  left: 0;
-  right: 0;
+  left: 50%;
   bottom: 0;
   display: flex;
   align-items: center;
@@ -82,7 +81,9 @@ nav.main-nav {
   background: var(--color-bg-light);
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
   z-index: 20;
-  transform: translateY(100%);
+  width: 100%;
+  max-width: var(--layout-max-width);
+  transform: translate(-50%, 100%);
   transition: transform 0.3s ease;
 }
 
@@ -97,11 +98,18 @@ nav.main-nav {
 }
 
 .scroll-buttons.visible {
-  transform: translateY(0);
+  transform: translate(-50%, 0);
 }
 
 body.has-scroll-buttons {
   padding-bottom: 4.5rem;
+}
+
+@media (min-width: 768px) {
+  .scroll-buttons {
+    justify-content: center;
+    gap: 3rem;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Center scroll buttons and price bar on wider viewports
- Keep Book/Contact actions grouped so desktop users don't scan to screen edges
- Increase spacing between price and action buttons for easier scanning

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beca6123bc8328b6bb1b74063c8a94