### PR TITLE
Fix layout of scroll buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -76,7 +76,8 @@ nav.main-nav {
   bottom: 0;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
+  gap: 1rem;
   padding: 0.75rem 1rem;
   background: var(--color-bg-light);
   box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
@@ -107,8 +108,7 @@ body.has-scroll-buttons {
 
 @media (min-width: 768px) {
   .scroll-buttons {
-    justify-content: center;
-    gap: 3rem;
+    justify-content: space-between;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adjust bottom scroll buttons so price aligns left and actions right on larger screens
- Right-align price and buttons together on mobile with spacing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beeab2de5c8328a7207b3e33421111