### PR TITLE
Add contact modal with call and email options

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -642,3 +642,52 @@ button:hover,
   font-size: 0.75rem;
   pointer-events: none;
 }
+/* Modal styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: var(--color-bg-light);
+  color: var(--color-text-primary);
+  padding: 2rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 500px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+.modal-logo {
+  margin: 0 auto;
+}
+
+.close-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--color-text-primary);
+}
+
+.name-fields {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.name-fields input {
+  flex: 1;
+}
+

--- a/app/properties/[slug]/PropertyDetailClient.tsx
+++ b/app/properties/[slug]/PropertyDetailClient.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState, FormEvent } from 'react';
 import Header from '@/components/Header';
 import SectionSlider from '@/components/SectionSlider';
+import ContactModal from '@/components/ContactModal';
 import type { Property } from '@/lib/properties';
 
 interface PropertyDetailClientProps {
@@ -11,13 +12,8 @@ interface PropertyDetailClientProps {
 }
 
 export default function PropertyDetailClient({ property }: PropertyDetailClientProps) {
-  const [contact, setContact] = useState({ name: '', email: '', message: '' });
+  const [contactOpen, setContactOpen] = useState(false);
   const [booking, setBooking] = useState({ checkIn: '', checkOut: '' });
-
-  const handleContactSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    alert('Contact request submitted');
-  };
 
   const handleBookingSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -31,7 +27,7 @@ export default function PropertyDetailClient({ property }: PropertyDetailClientP
         <div className="text">
           <p className="eyebrow">{property.location}</p>
           <h1>{property.title}</h1>
-          <LinkButtons />
+          <LinkButtons onContact={() => setContactOpen(true)} />
         </div>
         <div className="hero-image">
           <Image
@@ -62,32 +58,7 @@ export default function PropertyDetailClient({ property }: PropertyDetailClientP
         ))}
       </section>
 
-      <section id="contact">
-        <h2>Contact the Host</h2>
-        <form onSubmit={handleContactSubmit}>
-          <input
-            type="text"
-            placeholder="Name"
-            required
-            value={contact.name}
-            onChange={(e) => setContact({ ...contact, name: e.target.value })}
-          />
-          <input
-            type="email"
-            placeholder="Email"
-            required
-            value={contact.email}
-            onChange={(e) => setContact({ ...contact, email: e.target.value })}
-          />
-          <textarea
-            placeholder="Message"
-            required
-            value={contact.message}
-            onChange={(e) => setContact({ ...contact, message: e.target.value })}
-          />
-          <button type="submit">Send</button>
-        </form>
-      </section>
+      <ContactModal open={contactOpen} onClose={() => setContactOpen(false)} />
 
       <section id="book">
         <h2>Book This Property</h2>
@@ -117,20 +88,19 @@ export default function PropertyDetailClient({ property }: PropertyDetailClientP
         sections={[
           { id: 'hero', label: 'Overview' },
           { id: 'gallery', label: 'Gallery' },
-          { id: 'contact', label: 'Contact' },
-          { id: 'book', label: 'Book' },
+          { id: 'book', label: 'Book' }
         ]}
       />
     </>
   );
 }
 
-function LinkButtons() {
+function LinkButtons({ onContact }: { onContact: () => void }) {
   return (
     <div className="nav-links">
-      <a href="#contact" className="btn">
+      <button className="btn" onClick={onContact}>
         Contact
-      </a>
+      </button>
       <a href="#book" className="btn">
         Book Now
       </a>

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import Image from 'next/image';
+
+interface ContactModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function ContactModal({ open, onClose }: ContactModalProps) {
+  const [form, setForm] = useState({
+    email: '',
+    firstName: '',
+    lastName: '',
+    subject: '',
+    body: '',
+  });
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const mailto = `mailto:g.stroman3@gmail.com?subject=${encodeURIComponent(
+      form.subject
+    )}&body=${encodeURIComponent(
+      form.body +
+        `\n\nFrom: ${form.firstName} ${form.lastName}\nEmail: ${form.email}`
+    )}`;
+    window.location.href = mailto;
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <button className="close-btn" onClick={onClose} aria-label="Close">
+          &times;
+        </button>
+        <Image
+          src="/images/logo_white.png"
+          alt="Stroman Properties logo"
+          width={160}
+          height={40}
+          className="modal-logo"
+        />
+        <a href="tel:7039948444" className="btn call-btn">
+          Call
+        </a>
+        <form onSubmit={handleSubmit}>
+          <input
+            type="email"
+            placeholder="Email"
+            required
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+          />
+          <div className="name-fields">
+            <input
+              type="text"
+              placeholder="First Name"
+              required
+              value={form.firstName}
+              onChange={(e) =>
+                setForm({ ...form, firstName: e.target.value })
+              }
+            />
+            <input
+              type="text"
+              placeholder="Last Name"
+              required
+              value={form.lastName}
+              onChange={(e) =>
+                setForm({ ...form, lastName: e.target.value })
+              }
+            />
+          </div>
+          <input
+            type="text"
+            placeholder="Subject"
+            required
+            value={form.subject}
+            onChange={(e) => setForm({ ...form, subject: e.target.value })}
+          />
+          <textarea
+            placeholder="Body"
+            required
+            value={form.body}
+            onChange={(e) => setForm({ ...form, body: e.target.value })}
+          />
+          <button type="submit">Send Email</button>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import Header from '@/components/Header';
 import ScrollButtons from '@/components/ScrollButtons';
+import ContactModal from '@/components/ContactModal';
 
 const slides = [
   '/images/kitchen/IMG_0186.jpg',
@@ -17,6 +18,7 @@ const slides = [
 
 export default function HomePage(): ReactElement {
   const [index, setIndex] = useState(0);
+  const [contactOpen, setContactOpen] = useState(false);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -34,7 +36,7 @@ export default function HomePage(): ReactElement {
   return (
     <>
       <Header overlay />
-      <ScrollButtons />
+      <ScrollButtons onContact={() => setContactOpen(true)} />
       <section className="landing-hero">
         <div className="background">
           {slides.map((src, i) => (
@@ -53,10 +55,16 @@ export default function HomePage(): ReactElement {
           <p>Your comfortable stay in Ashburn, VA</p>
           <div className="actions">
             <Link href="/" className="btn">Book Now</Link>
-            <Link href="/" className="btn secondary">Contact</Link>
+            <button
+              className="btn secondary"
+              onClick={() => setContactOpen(true)}
+            >
+              Contact
+            </button>
           </div>
         </div>
       </section>
+      <ContactModal open={contactOpen} onClose={() => setContactOpen(false)} />
       <section id="about" className="alt-section">
           <article className="about-article">
           <h1>Luxe Townhome Retreat</h1>

--- a/components/ScrollButtons.tsx
+++ b/components/ScrollButtons.tsx
@@ -4,7 +4,13 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import type { ReactElement } from 'react';
 
-export default function ScrollButtons(): ReactElement | null {
+interface ScrollButtonsProps {
+  onContact?: () => void;
+}
+
+export default function ScrollButtons({
+  onContact,
+}: ScrollButtonsProps): ReactElement | null {
   const [visible, setVisible] = useState(false);
   const [enabled, setEnabled] = useState(false);
 
@@ -44,9 +50,9 @@ export default function ScrollButtons(): ReactElement | null {
         <Link href="/properties/#" className="btn">
           Book
         </Link>
-        <Link href="/#contact" className="btn outline">
+        <button className="btn outline" onClick={onContact}>
           Contact
-        </Link>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add reusable ContactModal with call or email options
- wire up Contact buttons on home and property pages to open modal
- style modal to match site palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68befdbea3808328982d62f7948b20e6