### PR TITLE
Fix contact modal alignment

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -685,8 +685,9 @@ button:hover,
 }
 
 .modal a.btn,
-.modal button {
+.modal button:not(.close-btn) {
   width: 100%;
+  display: block;
 }
 
 .modal input,


### PR DESCRIPTION
## Summary
- ensure call and email buttons span full modal width
- prevent close button from being stretched, keeping it top-right

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf1439d2188328936676c4598a90f5