### PR TITLE
Fix contact modal call button width overflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -688,6 +688,7 @@ button:hover,
 .modal button:not(.close-btn) {
   width: 100%;
   display: block;
+  box-sizing: border-box;
 }
 
 .modal input,


### PR DESCRIPTION
## Summary
- prevent contact modal call button from extending past modal edges

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf18373648832899cbcc26e244b2d4