### PR TITLE
Add spacing around contact modal on mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -670,6 +670,7 @@ button:hover,
   border-radius: 8px;
   width: 90%;
   max-width: 500px;
+  box-sizing: border-box;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure contact modal respects padding when calculating width so it's not edge-to-edge on small screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf343c64388328a075ed8e9b52bfcb