### PR TITLE
Add booking calendar page and update book links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,10 @@
   --color-text-primary: #033b88; /* Neutral Gray-Black */
   --color-text-secondary: #4B5563; /* Medium Gray */
   --layout-max-width: 1200px;
+  --available: #ffffff;
+  --booked: #ffe0e0;
+  --owner: #fff4d6;
+  --brand: var(--color-accent);
 }
 
 html {
@@ -725,4 +729,67 @@ button:hover,
     flex-direction: column;
   }
 }
+
+/* Availability calendar */
+.availability-calendar {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.availability-calendar .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.availability-calendar .header button {
+  background: none;
+  border: 1px solid var(--brand);
+  color: var(--brand);
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.availability-calendar .grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.25rem;
+}
+
+.availability-calendar .day-name {
+  text-align: center;
+  font-weight: 600;
+}
+
+.availability-calendar .day {
+  aspect-ratio: 1/1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+}
+
+.availability-calendar .day.available {
+  background: var(--available);
+}
+
+.availability-calendar .day.booked {
+  background: var(--booked);
+}
+
+.availability-calendar .day.owner {
+  background: var(--owner);
+}
+
+.availability-calendar .day[aria-disabled="true"] {
+  opacity: 0.6;
+}
+
+@media (min-width: 600px) {
+  .availability-calendar {
+    max-width: 600px;
+  }
+}
+
 

--- a/app/properties/[slug]/PropertyDetailClient.tsx
+++ b/app/properties/[slug]/PropertyDetailClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useState, FormEvent } from 'react';
 import Header from '@/components/Header';
 import SectionSlider from '@/components/SectionSlider';
@@ -27,7 +28,7 @@ export default function PropertyDetailClient({ property }: PropertyDetailClientP
         <div className="text">
           <p className="eyebrow">{property.location}</p>
           <h1>{property.title}</h1>
-          <LinkButtons onContact={() => setContactOpen(true)} />
+          <LinkButtons onContact={() => setContactOpen(true)} slug={property.slug} />
         </div>
         <div className="hero-image">
           <Image
@@ -95,15 +96,15 @@ export default function PropertyDetailClient({ property }: PropertyDetailClientP
   );
 }
 
-function LinkButtons({ onContact }: { onContact: () => void }) {
+function LinkButtons({ onContact, slug }: { onContact: () => void; slug: string }) {
   return (
     <div className="nav-links">
       <button className="btn" onClick={onContact}>
         Contact
       </button>
-      <a href="#book" className="btn">
+      <Link href={`/properties/${slug}/book`} className="btn">
         Book Now
-      </a>
+      </Link>
     </div>
   );
 }

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation';
+import Header from '@/components/Header';
+import { AvailabilityCalendar } from '@/components/AvailabilityCalendar';
+import availability from '@/lib/availability.json';
+import { getPropertyBySlug, properties } from '@/lib/properties';
+
+export default async function BookPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const property = getPropertyBySlug(slug);
+  if (!property) return notFound();
+  return (
+    <>
+      <Header />
+      <section className="book-page">
+        <h1>Book {property.title}</h1>
+        <AvailabilityCalendar data={availability} />
+      </section>
+    </>
+  );
+}
+
+export function generateStaticParams() {
+  return properties.map(({ slug }) => ({ slug }));
+}

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -55,7 +55,7 @@ export default function PropertiesPage(): ReactElement {
     return (
         <>
            <Header overlay />
-           <ScrollButtons />
+           <ScrollButtons slug={property.slug} />
             <section className="gallery-hero">
                 <div className="background">
                     {heroSlides.map((src, i) => (

--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+
+export interface DateRange {
+  start: string;
+  end: string;
+  reason?: string;
+}
+
+export interface AvailabilityData {
+  property_id: string;
+  booked: DateRange[];
+  blackouts: DateRange[];
+  min_nights: number;
+}
+
+export interface AvailabilityCalendarProps {
+  data: AvailabilityData;
+}
+
+function inRange(date: Date, range: DateRange): boolean {
+  const start = new Date(range.start);
+  const end = new Date(range.end);
+  return date >= start && date <= end;
+}
+
+export function AvailabilityCalendar({ data }: AvailabilityCalendarProps): ReactElement {
+  const [month, setMonth] = useState(new Date());
+
+  const daysInMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
+  const firstDay = new Date(month.getFullYear(), month.getMonth(), 1).getDay();
+  const days: Date[] = [];
+  for (let i = 1; i <= daysInMonth; i++) {
+    days.push(new Date(month.getFullYear(), month.getMonth(), i));
+  }
+
+  const isBooked = (date: Date) => data.booked.some((r) => inRange(date, r));
+  const isOwner = (date: Date) => data.blackouts.some((r) => inRange(date, r));
+
+  const prevMonth = () => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1));
+  const nextMonth = () => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1));
+
+  return (
+    <div className="availability-calendar">
+      <div className="header">
+        <button onClick={prevMonth} aria-label="Previous Month">&lt;</button>
+        <h2>{month.toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
+        <button onClick={nextMonth} aria-label="Next Month">&gt;</button>
+      </div>
+      <div className="grid" role="grid">
+        {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d) => (
+          <div key={d} className="day-name">
+            {d}
+          </div>
+        ))}
+        {Array.from({ length: firstDay }).map((_, i) => (
+          <div key={`empty-${i}`} className="empty" />
+        ))}
+        {days.map((date) => {
+          const booked = isBooked(date);
+          const owner = isOwner(date);
+          const cls = owner ? 'owner' : booked ? 'booked' : 'available';
+          return (
+            <div
+              key={date.toISOString()}
+              role="gridcell"
+              aria-disabled={booked || owner}
+              className={`day ${cls}`}
+            >
+              {date.getDate()}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default AvailabilityCalendar;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ export default function Header({ overlay = false }: HeaderProps): ReactElement {
         <div className="nav-links">
           <Link href="/#about">About</Link>
           <Link href="/properties">Gallery</Link>
-          <Link href="#">Book</Link>
+          <Link href="/properties/ashburn-estate/book">Book</Link>
         </div>
       </nav>
     </header>

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -7,6 +7,7 @@ import type { ReactElement } from 'react';
 import Header from '@/components/Header';
 import ScrollButtons from '@/components/ScrollButtons';
 import ContactModal from '@/components/ContactModal';
+import { properties } from '@/lib/properties';
 
 const slides = [
   '/images/kitchen/IMG_0186.jpg',
@@ -19,6 +20,7 @@ const slides = [
 export default function HomePage(): ReactElement {
   const [index, setIndex] = useState(0);
   const [contactOpen, setContactOpen] = useState(false);
+  const slug = properties[0].slug;
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -36,7 +38,7 @@ export default function HomePage(): ReactElement {
   return (
     <>
       <Header overlay />
-      <ScrollButtons onContact={() => setContactOpen(true)} />
+      <ScrollButtons onContact={() => setContactOpen(true)} slug={slug} />
       <section className="landing-hero">
         <div className="background">
           {slides.map((src, i) => (
@@ -54,7 +56,7 @@ export default function HomePage(): ReactElement {
           <h1>Luxe Townhome Retreat</h1>
           <p>Your comfortable stay in Ashburn, VA</p>
           <div className="actions">
-            <Link href="/" className="btn">Book Now</Link>
+            <Link href={`/properties/${slug}/book`} className="btn">Book Now</Link>
             <button
               className="btn secondary"
               onClick={() => setContactOpen(true)}

--- a/components/ScrollButtons.tsx
+++ b/components/ScrollButtons.tsx
@@ -6,10 +6,12 @@ import type { ReactElement } from 'react';
 
 interface ScrollButtonsProps {
   onContact?: () => void;
+  slug: string;
 }
 
 export default function ScrollButtons({
   onContact,
+  slug,
 }: ScrollButtonsProps): ReactElement | null {
   const [visible, setVisible] = useState(false);
   const [enabled, setEnabled] = useState(false);
@@ -47,7 +49,7 @@ export default function ScrollButtons({
     <div className={`scroll-buttons${visible ? ' visible' : ''}`}>
       <span className="price">$315/night</span>
       <div className="actions">
-        <Link href="/properties/#" className="btn">
+        <Link href={`/properties/${slug}/book`} className="btn">
           Book
         </Link>
         <button className="btn outline" onClick={onContact}>

--- a/lib/availability.json
+++ b/lib/availability.json
@@ -1,0 +1,11 @@
+{
+  "property_id": "ashburn-estate",
+  "booked": [
+    {"start":"2025-09-12","end":"2025-09-15"},
+    {"start":"2025-10-01","end":"2025-10-05"}
+  ],
+  "blackouts": [
+    {"start":"2025-11-20","end":"2025-11-23","reason":"Owner"}
+  ],
+  "min_nights": 2
+}


### PR DESCRIPTION
## Summary
- add reusable `AvailabilityCalendar` component and mock availability data
- introduce `/properties/[slug]/book` page rendering the calendar
- route all existing Book buttons to the new booking page and style calendar with CSS variables

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf6917eae48328b8b04597907561ab