### PR TITLE
Switch calendar header to contact modal with transparent logo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,11 +66,21 @@ nav.main-nav {
   font-weight: 550;
 }
 
-.main-nav .nav-links a {
+.nav-links button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.main-nav .nav-links a,
+.main-nav .nav-links button {
   color: var(--color-text-primary);
 }
 
-.main-nav .nav-links a:hover {
+.main-nav .nav-links a:hover,
+.main-nav .nav-links button:hover {
   color: var(--color-accent);
 }
 
@@ -387,17 +397,20 @@ button:hover,
   border: none;
 }
 
-.header-overlay .nav-links a:hover{
+.header-overlay .nav-links a:hover,
+.header-overlay .nav-links button:hover{
     color: #fff;
 }
 
-.header-overlay .nav-links a {
+.header-overlay .nav-links a,
+.header-overlay .nav-links button {
   color: #fff;
   position: relative;
   text-decoration: none;
 }
 
-.header-overlay .nav-links a::after {
+.header-overlay .nav-links a::after,
+.header-overlay .nav-links button::after {
     content: '';
     position: absolute;
     left: 0;
@@ -408,7 +421,8 @@ button:hover,
     transition: width 0.3s ease;
 }
 
-.header-overlay .nav-links a:hover::after {
+.header-overlay .nav-links a:hover::after,
+.header-overlay .nav-links button:hover::after {
   width: 100%; /* Full width underline on hover */
 }
 

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -14,7 +14,7 @@ export default async function BookPage({
   if (!property) return notFound();
   return (
     <>
-      <Header />
+      <Header logo="transparent" contact />
       <section className="book-page">
         <h1>Book {property.title}</h1>
         <AvailabilityCalendar data={availability} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,19 +2,32 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
+import ContactModal from '@/components/ContactModal';
 
 interface HeaderProps {
   overlay?: boolean;
+  logo?: 'white' | 'transparent';
+  contact?: boolean;
 }
 
-export default function Header({ overlay = false }: HeaderProps): ReactElement {
+export default function Header({
+  overlay = false,
+  logo = 'white',
+  contact = false,
+}: HeaderProps): ReactElement {
+  const [contactOpen, setContactOpen] = useState(false);
+  const logoSrc =
+    logo === 'transparent'
+      ? '/images/logo_transparent.png'
+      : '/images/logo_white.png';
   return (
     <header className={overlay ? 'header-overlay' : undefined}>
       <nav className="main-nav">
         <Link href="/" className="logo">
           <Image
-            src="/images/logo_white.png"
+            src={logoSrc}
             alt="Stroman Properties logo"
             width={160}
             height={40}
@@ -24,9 +37,16 @@ export default function Header({ overlay = false }: HeaderProps): ReactElement {
         <div className="nav-links">
           <Link href="/#about">About</Link>
           <Link href="/properties">Gallery</Link>
-          <Link href="/properties/ashburn-estate/book">Book</Link>
+          {contact ? (
+            <button onClick={() => setContactOpen(true)}>Contact</button>
+          ) : (
+            <Link href="/properties/ashburn-estate/book">Book</Link>
+          )}
         </div>
       </nav>
+      {contact && (
+        <ContactModal open={contactOpen} onClose={() => setContactOpen(false)} />
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Add optional `contact` and `logo` props to `Header` so nav can show a Contact button and swap logo variants
- Style header nav buttons and overlay variants to match existing links
- Use the new header on the booking calendar page with a transparent logo and contact modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf97fb9b708328afaeb94dc6ff5147