### PR TITLE
Fix booking page heading visibility and layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -203,6 +203,17 @@ p, label {
   color: #FFF;
 }
 
+/* Booking page */
+.book-page {
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+}
+
+.book-page h1 {
+  color: var(--color-primary);
+  text-align: center;
+}
+
 .gallery {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Ensure booking page heading uses primary color variable for visibility
- Constrain booking page content width to match header and center it

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf9acdcf6c83288ae6c3a11dbf5cef