### PR TITLE
feat: sync booking calendar with Airbnb

### DIFF
--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from 'next/navigation';
 import Header from '@/components/Header';
 import { AvailabilityCalendar } from '@/components/AvailabilityCalendar';
-import availability from '@/lib/availability.json';
+import defaultAvailability from '@/lib/availability.json';
 import { getPropertyBySlug, properties } from '@/lib/properties';
+import { fetchAvailabilityFromIcal } from '@/lib/airbnb';
+import type { AvailabilityData } from '@/lib/availability';
 
 export default async function BookPage({
   params,
@@ -12,6 +14,16 @@ export default async function BookPage({
   const { slug } = await params;
   const property = getPropertyBySlug(slug);
   if (!property) return notFound();
+
+  let availability: AvailabilityData = defaultAvailability;
+  if (property.icalUrl) {
+    try {
+      availability = await fetchAvailabilityFromIcal(property.icalUrl, property.slug);
+    } catch (err) {
+      console.error('Failed to fetch iCal availability', err);
+    }
+  }
+
   return (
     <>
       <Header logo="transparent" contact />

--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -2,19 +2,7 @@
 
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-
-export interface DateRange {
-  start: string;
-  end: string;
-  reason?: string;
-}
-
-export interface AvailabilityData {
-  property_id: string;
-  booked: DateRange[];
-  blackouts: DateRange[];
-  min_nights: number;
-}
+import type { AvailabilityData, DateRange } from '@/lib/availability';
 
 export interface AvailabilityCalendarProps {
   data: AvailabilityData;

--- a/lib/airbnb.ts
+++ b/lib/airbnb.ts
@@ -1,0 +1,33 @@
+import type { AvailabilityData, DateRange } from './availability';
+
+function formatDate(value: string): string {
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+export async function fetchAvailabilityFromIcal(
+  url: string,
+  propertyId: string,
+): Promise<AvailabilityData> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch iCal: ${res.status}`);
+  }
+  const ics = await res.text();
+  const booked: DateRange[] = [];
+  const eventRegex = /BEGIN:VEVENT\s+([\s\S]*?)END:VEVENT/g;
+  let match: RegExpExecArray | null;
+  while ((match = eventRegex.exec(ics)) !== null) {
+    const body = match[1];
+    const start = /DTSTART(?:;VALUE=DATE)?:(\d{8})/i.exec(body);
+    const end = /DTEND(?:;VALUE=DATE)?:(\d{8})/i.exec(body);
+    if (start && end) {
+      booked.push({ start: formatDate(start[1]), end: formatDate(end[1]) });
+    }
+  }
+  return {
+    property_id: propertyId,
+    booked,
+    blackouts: [],
+    min_nights: 1,
+  };
+}

--- a/lib/availability.ts
+++ b/lib/availability.ts
@@ -1,0 +1,12 @@
+export interface DateRange {
+  start: string;
+  end: string;
+  reason?: string;
+}
+
+export interface AvailabilityData {
+  property_id: string;
+  booked: DateRange[];
+  blackouts: DateRange[];
+  min_nights: number;
+}

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -18,6 +18,7 @@ export type Property = {
   bedrooms: number;
   beds: number;
   bathrooms: number;
+  icalUrl?: string;
 };
 
 export const properties: Property[] = [
@@ -26,6 +27,7 @@ export const properties: Property[] = [
     title: 'Ashburn Estate',
     location: 'Ashburn, VA',
     hero: { src: '/images/front-house/front-right.jpg', alt: 'Luxury home exterior' },
+    icalUrl: 'https://www.airbnb.com/calendar/ical/54023802.ics?s=7ed74f559aa0cf7c1c71d979b3e046bf',
     guests: 10,
     bedrooms: 3,
     beds: 4,


### PR DESCRIPTION
## Summary
- load booking availability from Airbnb iCal feed
- share availability types across client and server
- auto-sync calendar on booking page using property iCal URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05eebc4588328bd1ce4a499057209