### PR TITLE
Add month/year dropdown navigation to availability calendar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -778,6 +778,19 @@ button:hover,
   cursor: pointer;
 }
 
+.availability-calendar .header .selectors {
+  display: flex;
+  align-items: center;
+}
+
+.availability-calendar .header select {
+  background: none;
+  border: 1px solid var(--color-bg-light);
+  color: var(--color-bg-light);
+  padding: 0.25rem;
+  margin: 0 0.25rem;
+}
+
 .availability-calendar .grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);

--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { ReactElement } from 'react';
+import type { ReactElement, ChangeEvent } from 'react';
 import type { AvailabilityData, DateRange } from '@/lib/availability';
 
 export interface AvailabilityCalendarProps {
@@ -17,6 +17,12 @@ function inRange(date: Date, range: DateRange): boolean {
 export function AvailabilityCalendar({ data }: AvailabilityCalendarProps): ReactElement {
   const [month, setMonth] = useState(new Date());
 
+  const monthNames = Array.from({ length: 12 }, (_, i) =>
+    new Date(0, i).toLocaleString('default', { month: 'long' })
+  );
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: 11 }, (_, i) => currentYear - 5 + i);
+
   const daysInMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
   const firstDay = new Date(month.getFullYear(), month.getMonth(), 1).getDay();
   const days: Date[] = [];
@@ -27,14 +33,43 @@ export function AvailabilityCalendar({ data }: AvailabilityCalendarProps): React
   const isBooked = (date: Date) => data.booked.some((r) => inRange(date, r));
   const isOwner = (date: Date) => data.blackouts.some((r) => inRange(date, r));
 
-  const prevMonth = () => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1));
-  const nextMonth = () => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1));
+  const prevMonth = () =>
+    setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1));
+  const nextMonth = () =>
+    setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1));
+  const changeMonth = (e: ChangeEvent<HTMLSelectElement>) =>
+    setMonth(new Date(month.getFullYear(), Number(e.target.value), 1));
+  const changeYear = (e: ChangeEvent<HTMLSelectElement>) =>
+    setMonth(new Date(Number(e.target.value), month.getMonth(), 1));
 
   return (
     <div className="availability-calendar">
       <div className="header">
         <button onClick={prevMonth} aria-label="Previous Month">&lt;</button>
-        <h2>{month.toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
+        <div className="selectors">
+          <select
+            aria-label="Select Month"
+            value={month.getMonth()}
+            onChange={changeMonth}
+          >
+            {monthNames.map((m, i) => (
+              <option key={m} value={i}>
+                {m}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Select Year"
+            value={month.getFullYear()}
+            onChange={changeYear}
+          >
+            {years.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
+        </div>
         <button onClick={nextMonth} aria-label="Next Month">&gt;</button>
       </div>
       <div className="grid" role="grid">


### PR DESCRIPTION
## Summary
- add month and year select controls to availability calendar header
- style selectors to match existing calendar design

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0632771b8832882cbb94f2b6ce6cb