### PR TITLE
style: restyle calendar dropdown heading

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -785,10 +785,20 @@ button:hover,
 
 .availability-calendar .header select {
   background: none;
-  border: 1px solid var(--color-bg-light);
+  border: none;
   color: var(--color-bg-light);
-  padding: 0.25rem;
+  padding: 0;
   margin: 0 0.25rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  appearance: none;
+  outline: none;
+}
+
+.availability-calendar .header select option {
+  color: var(--color-primary);
+  background: var(--color-bg-light);
 }
 
 .availability-calendar .grid {


### PR DESCRIPTION
## Summary
- enlarge calendar month/year selectors to act as heading
- remove dropdown borders and use primary color for options

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*


------
https://chatgpt.com/codex/tasks/task_e_68c0666c0b20832888ba62441e6e338c