### PR TITLE
Add ICS-based availability calendar with owner blackouts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,10 +11,11 @@
   --color-text-primary: #033b88; /* Neutral Gray-Black */
   --color-text-secondary: #4B5563; /* Medium Gray */
   --layout-max-width: 1200px;
-  --available: #ffffff;
-  --booked: #ffe0e0;
-  --owner: #fff4d6;
   --brand: var(--color-accent);
+  --available-bg: #ffffff;
+  --booked-bg: #ffe0e0;
+  --blackout-bg: #fff4d6;
+  --grid-border: #ddd;
 }
 
 html {
@@ -767,7 +768,7 @@ button:hover,
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
-  background: var(--color-primary);
+  background: var(--brand);
   /* increase vertical space without affecting width */
   padding: clamp(0.75rem, 3vw, 1.5rem) 0;
 }
@@ -826,18 +827,19 @@ button:hover,
   align-items: center;
   justify-content: center;
   font-size: 0.875rem;
+  border: 1px solid var(--grid-border);
 }
 
 .availability-calendar .day.available {
-  background: var(--available);
+  background: var(--available-bg);
 }
 
 .availability-calendar .day.booked {
-  background: var(--booked);
+  background: var(--booked-bg);
 }
 
-.availability-calendar .day.owner {
-  background: var(--owner);
+.availability-calendar .day.blackout {
+  background: var(--blackout-bg);
 }
 
 .availability-calendar .day[aria-disabled="true"] {

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,40 +1,17 @@
-import { notFound } from 'next/navigation';
-import Header from '@/components/Header';
-import { AvailabilityCalendar } from '@/components/AvailabilityCalendar';
-import defaultAvailability from '@/lib/availability.json';
-import { getPropertyBySlug, properties } from '@/lib/properties';
-import { fetchAvailabilityFromIcal } from '@/lib/airbnb';
-import type { AvailabilityData } from '@/lib/availability';
+import AvailabilityCalendar from '@/components/AvailabilityCalendar';
+import { getAvailability } from '@/lib/availabilityApi';
 
-export default async function BookPage({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
-  const { slug } = await params;
-  const property = getPropertyBySlug(slug);
-  if (!property) return notFound();
-
-  let availability: AvailabilityData = defaultAvailability;
-  if (property.icalUrl) {
-    try {
-      availability = await fetchAvailabilityFromIcal(property.icalUrl, property.slug);
-    } catch (err) {
-      console.error('Failed to fetch iCal availability', err);
-    }
-  }
-
+export default function Page({ params }: { params: { slug: string } }) {
+  const propertyId = params.slug; // keep simple for now
   return (
     <>
-      <Header logo="transparent" contact />
-      <section className="book-page">
-        <h1>Book {property.title}</h1>
-        <AvailabilityCalendar data={availability} />
-      </section>
+      <h1>Availability for {propertyId}</h1>
+      <AvailabilityCalendar
+        propertyId={propertyId}
+        timezone="America/New_York"
+        fetchAvailability={getAvailability}
+        showOwnerPanel={false} // set true temporarily to test blackouts
+      />
     </>
   );
-}
-
-export function generateStaticParams() {
-  return properties.map(({ slug }) => ({ slug }));
 }

--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -1,72 +1,72 @@
 'use client';
 
-import { useState } from 'react';
-import type { ReactElement, ChangeEvent } from 'react';
-import type { AvailabilityData, DateRange } from '@/lib/availability';
+import { useState, useEffect, ChangeEvent, useCallback } from 'react';
+import type { AvailabilityFeed, DateRange } from './types';
+import OwnerBlackoutsPanel from './OwnerBlackoutsPanel';
+import { formatInTimeZone, utcToZonedTime } from 'date-fns-tz';
+import { startOfMonth, addMonths, getDaysInMonth, addDays } from 'date-fns';
 
-export interface AvailabilityCalendarProps {
-  data: AvailabilityData;
+export type Props = {
+  propertyId: string;
+  timezone: string;
+  fetchAvailability: (args: { propertyId: string; start?: string; end?: string }) => Promise<AvailabilityFeed>;
+  showOwnerPanel?: boolean; // default false
+};
+
+function inRanges(iso: string, ranges: DateRange[]): boolean {
+  return ranges.some((r) => r.start <= iso && iso < r.end);
 }
 
-function inRange(date: Date, range: DateRange): boolean {
-  const start = new Date(range.start);
-  const end = new Date(range.end);
-  return date >= start && date <= end;
-}
+export default function AvailabilityCalendar({ propertyId, timezone, fetchAvailability, showOwnerPanel = false }: Props) {
+  const [month, setMonth] = useState(() => utcToZonedTime(new Date(), timezone));
+  const [feed, setFeed] = useState<AvailabilityFeed>({ property_id: propertyId, booked: [], blackouts: [], min_nights: 1 });
 
-export function AvailabilityCalendar({ data }: AvailabilityCalendarProps): ReactElement {
-  const [month, setMonth] = useState(new Date());
+  const monthStart = startOfMonth(month);
+  const monthEnd = addMonths(monthStart, 1);
+  const monthStartISO = formatInTimeZone(monthStart, timezone, 'yyyy-MM-dd');
+  const monthEndISO = formatInTimeZone(monthEnd, timezone, 'yyyy-MM-dd');
 
-  const monthNames = Array.from({ length: 12 }, (_, i) =>
-    new Date(0, i).toLocaleString('default', { month: 'long' })
-  );
-  const currentYear = new Date().getFullYear();
-  const years = Array.from({ length: 11 }, (_, i) => currentYear - 5 + i);
+  const refetch = useCallback(() => {
+    fetchAvailability({ propertyId, start: monthStartISO, end: monthEndISO }).then(setFeed);
+  }, [propertyId, monthStartISO, monthEndISO, fetchAvailability]);
 
-  const daysInMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
-  const firstDay = new Date(month.getFullYear(), month.getMonth(), 1).getDay();
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  const daysIn = getDaysInMonth(monthStart);
+  const firstDay = monthStart.getDay();
   const days: Date[] = [];
-  for (let i = 1; i <= daysInMonth; i++) {
-    days.push(new Date(month.getFullYear(), month.getMonth(), i));
+  for (let i = 0; i < daysIn; i++) {
+    days.push(addDays(monthStart, i));
   }
 
-  const isBooked = (date: Date) => data.booked.some((r) => inRange(date, r));
-  const isOwner = (date: Date) => data.blackouts.some((r) => inRange(date, r));
-
-  const prevMonth = () =>
-    setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1));
-  const nextMonth = () =>
-    setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1));
-  const changeMonth = (e: ChangeEvent<HTMLSelectElement>) =>
+  const changeMonth = (e: ChangeEvent<HTMLSelectElement>) => {
     setMonth(new Date(month.getFullYear(), Number(e.target.value), 1));
-  const changeYear = (e: ChangeEvent<HTMLSelectElement>) =>
+  };
+  const changeYear = (e: ChangeEvent<HTMLSelectElement>) => {
     setMonth(new Date(Number(e.target.value), month.getMonth(), 1));
+  };
+  const prevMonth = () => setMonth(addMonths(month, -1));
+  const nextMonth = () => setMonth(addMonths(month, 1));
+
+  const monthNames = Array.from({ length: 12 }, (_, i) => new Date(0, i).toLocaleString('default', { month: 'long' }));
+  const currentYear = new Date().getFullYear();
+  const years = Array.from({ length: 11 }, (_, i) => currentYear - 5 + i);
 
   return (
     <div className="availability-calendar">
       <div className="header">
         <button onClick={prevMonth} aria-label="Previous Month">&lt;</button>
         <div className="selectors">
-          <select
-            aria-label="Select Month"
-            value={month.getMonth()}
-            onChange={changeMonth}
-          >
+          <select aria-label="Select Month" value={month.getMonth()} onChange={changeMonth}>
             {monthNames.map((m, i) => (
-              <option key={m} value={i}>
-                {m}
-              </option>
+              <option key={m} value={i}>{m}</option>
             ))}
           </select>
-          <select
-            aria-label="Select Year"
-            value={month.getFullYear()}
-            onChange={changeYear}
-          >
+          <select aria-label="Select Year" value={month.getFullYear()} onChange={changeYear}>
             {years.map((y) => (
-              <option key={y} value={y}>
-                {y}
-              </option>
+              <option key={y} value={y}>{y}</option>
             ))}
           </select>
         </div>
@@ -74,31 +74,24 @@ export function AvailabilityCalendar({ data }: AvailabilityCalendarProps): React
       </div>
       <div className="grid" role="grid">
         {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map((d) => (
-          <div key={d} className="day-name">
-            {d}
-          </div>
+          <div key={d} className="day-name">{d}</div>
         ))}
         {Array.from({ length: firstDay }).map((_, i) => (
           <div key={`empty-${i}`} className="empty" />
         ))}
         {days.map((date) => {
-          const booked = isBooked(date);
-          const owner = isOwner(date);
-          const cls = owner ? 'owner' : booked ? 'booked' : 'available';
+          const iso = formatInTimeZone(date, timezone, 'yyyy-MM-dd');
+          const booked = inRanges(iso, feed.booked);
+          const blackout = inRanges(iso, feed.blackouts);
+          const cls = blackout ? 'blackout' : booked ? 'booked' : 'available';
           return (
-            <div
-              key={date.toISOString()}
-              role="gridcell"
-              aria-disabled={booked || owner}
-              className={`day ${cls}`}
-            >
+            <div key={iso} role="gridcell" aria-disabled={booked || blackout} className={`day ${cls}`}>
               {date.getDate()}
             </div>
           );
         })}
       </div>
+      {showOwnerPanel && <OwnerBlackoutsPanel propertyId={propertyId} onChange={refetch} />}
     </div>
   );
 }
-
-export default AvailabilityCalendar;

--- a/components/OwnerBlackoutsPanel.tsx
+++ b/components/OwnerBlackoutsPanel.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { getBlackouts, saveBlackouts } from '@/lib/ownerBlackouts';
+import { coalesce } from './utils/coalesce';
+import type { DateRange } from './types';
+
+interface Props {
+  propertyId: string;
+  onChange?: () => void;
+}
+
+export default function OwnerBlackoutsPanel({ propertyId, onChange }: Props) {
+  const [ranges, setRanges] = useState<DateRange[]>([]);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+
+  useEffect(() => {
+    setRanges(getBlackouts(propertyId));
+  }, [propertyId]);
+
+  const add = () => {
+    if (!start || !end || start >= end) return;
+    const updated = coalesce([...ranges, { start, end }]);
+    setRanges(updated);
+    saveBlackouts(propertyId, updated);
+    setStart('');
+    setEnd('');
+    onChange?.();
+  };
+
+  const remove = (idx: number) => {
+    const updated = ranges.filter((_, i) => i !== idx);
+    setRanges(updated);
+    saveBlackouts(propertyId, updated);
+    onChange?.();
+  };
+
+  return (
+    <div className="owner-blackouts">
+      <h3>Owner Blackouts</h3>
+      <ul>
+        {ranges.map((r, i) => (
+          <li key={`${r.start}-${r.end}`}>
+            {r.start} → {r.end}
+            <button onClick={() => remove(i)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      <div className="form">
+        <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+        <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+        <button onClick={add}>Add</button>
+      </div>
+    </div>
+  );
+}

--- a/components/types.ts
+++ b/components/types.ts
@@ -1,0 +1,15 @@
+export type ISODate = string;           // "YYYY-MM-DD"
+export type DateRange = { start: ISODate; end: ISODate }; // end is exclusive
+export type AvailabilityFeed = {
+  property_id: string;
+  booked: DateRange[];    // external imports (ICS)
+  blackouts: DateRange[]; // owner-set holds
+  min_nights?: number;
+};
+export type ICSRawEvent = {
+  dtstart: string;
+  dtend: string;
+  allDay: boolean;
+  uid?: string;
+  summary?: string;
+};

--- a/components/utils/coalesce.ts
+++ b/components/utils/coalesce.ts
@@ -1,0 +1,18 @@
+import type { DateRange } from '../types';
+
+export function coalesce(ranges: DateRange[]): DateRange[] {
+  if (!ranges.length) return [];
+  const sorted = [...ranges].sort((a, b) => a.start.localeCompare(b.start));
+  const merged: DateRange[] = [];
+  let cur = { ...sorted[0] };
+  for (const r of sorted.slice(1)) {
+    if (r.start <= cur.end) {
+      if (r.end > cur.end) cur.end = r.end;
+    } else {
+      merged.push(cur);
+      cur = { ...r };
+    }
+  }
+  merged.push(cur);
+  return merged;
+}

--- a/components/utils/tzNormalize.ts
+++ b/components/utils/tzNormalize.ts
@@ -1,0 +1,31 @@
+import { parse, format, startOfDay, addDays } from 'date-fns';
+import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
+import type { DateRange, ICSRawEvent } from '../types';
+
+function parseDate(value: string, tz: string): Date {
+  if (/^\d{8}$/.test(value)) {
+    const naive = parse(value, 'yyyyMMdd', new Date());
+    return zonedTimeToUtc(naive, tz);
+  }
+  // handles Z or offset via X token
+  return parse(value, "yyyyMMdd'T'HHmmssX", new Date());
+}
+
+export function normalizeICS(e: ICSRawEvent, tz: string): DateRange {
+  const startUtc = parseDate(e.dtstart, tz);
+  const endUtc = parseDate(e.dtend, tz);
+  const startZ = utcToZonedTime(startUtc, tz);
+  const endZ = utcToZonedTime(endUtc, tz);
+
+  const start = e.allDay ? startZ : startOfDay(startZ);
+  let end = e.allDay ? endZ : startOfDay(endZ);
+
+  if (end <= start) {
+    end = addDays(start, 1);
+  }
+
+  return {
+    start: format(start, 'yyyy-MM-dd'),
+    end: format(end, 'yyyy-MM-dd'),
+  };
+}

--- a/lib/availabilityApi.ts
+++ b/lib/availabilityApi.ts
@@ -1,0 +1,53 @@
+import { fetchICS, parseICS } from './icsImporter';
+import { normalizeICS } from '@/components/utils/tzNormalize';
+import { coalesce } from '@/components/utils/coalesce';
+import { getBlackouts } from './ownerBlackouts';
+import type { AvailabilityFeed, DateRange, ISODate } from '@/components/types';
+
+const PROPERTY_CONFIG: Record<string, { timezone: string; icsUrls: string[]; minNights?: number }> = {
+  // Hardcode for now; TODO: load from Supabase later
+  'beach-cottage-1': {
+    timezone: 'America/New_York',
+    icsUrls: ['<PASTE_CLIENT_ICS_URL_HERE>'],
+    minNights: 2,
+  },
+};
+
+export async function getAvailability(args: { propertyId: string; start?: ISODate; end?: ISODate }): Promise<AvailabilityFeed> {
+  const cfg = PROPERTY_CONFIG[args.propertyId] ?? { timezone: 'America/New_York', icsUrls: [] };
+  const allImported: DateRange[] = [];
+
+  for (const url of cfg.icsUrls) {
+    try {
+      const ics = await fetchICS(url);
+      const raw = parseICS(ics);
+      for (const ev of raw) {
+        const r = normalizeICS(ev, cfg.timezone);
+        allImported.push(r);
+      }
+    } catch {
+      // swallow per-source errors; log if desired
+    }
+  }
+
+  const booked = coalesce(allImported);
+  const blackouts = coalesce(getBlackouts(args.propertyId));
+
+  // Optional: filter to window [start,end) if provided
+  const within = (r: DateRange) => {
+    if (!args.start && !args.end) return true;
+    const s = args.start ?? '0000-01-01';
+    const e = args.end ?? '9999-12-31';
+    return r.start < e && r.end > s;
+  };
+
+  return {
+    property_id: args.propertyId,
+    booked: booked.filter(within),
+    blackouts: blackouts.filter(within),
+    min_nights: cfg.minNights ?? 2,
+  };
+}
+
+// TODO: Replace PROPERTY_CONFIG + blackouts with Supabase queries later.
+// TODO: Persist parsed/coalesced imports in DB + cron to avoid reparsing on each request.

--- a/lib/icsImporter.ts
+++ b/lib/icsImporter.ts
@@ -1,0 +1,42 @@
+import type { ICSRawEvent } from '@/components/types';
+
+export async function fetchICS(url: string): Promise<string> {
+  const res = await fetch(url);
+  return res.text();
+}
+
+export function parseICS(ics: string): ICSRawEvent[] {
+  const events: ICSRawEvent[] = [];
+  const lines = ics.split(/\r?\n/);
+  let cur: Partial<ICSRawEvent> | null = null;
+  for (const line of lines) {
+    if (line.startsWith('BEGIN:VEVENT')) {
+      cur = {};
+    } else if (line.startsWith('END:VEVENT')) {
+      if (cur && cur.dtstart && cur.dtend) {
+        const allDay =
+          /^\d{8}$/.test(cur.dtstart) && /^\d{8}$/.test(cur.dtend) ||
+          (cur.dtstart.endsWith('T000000') && cur.dtend.endsWith('T000000'));
+        events.push({
+          dtstart: cur.dtstart,
+          dtend: cur.dtend,
+          allDay,
+          uid: cur.uid,
+          summary: cur.summary,
+        });
+      }
+      cur = null;
+    } else if (cur) {
+      if (line.startsWith('DTSTART')) {
+        cur.dtstart = line.substring(line.indexOf(':') + 1);
+      } else if (line.startsWith('DTEND')) {
+        cur.dtend = line.substring(line.indexOf(':') + 1);
+      } else if (line.startsWith('UID')) {
+        cur.uid = line.substring(line.indexOf(':') + 1);
+      } else if (line.startsWith('SUMMARY')) {
+        cur.summary = line.substring(line.indexOf(':') + 1);
+      }
+    }
+  }
+  return events;
+}

--- a/lib/ownerBlackouts.ts
+++ b/lib/ownerBlackouts.ts
@@ -1,0 +1,27 @@
+import type { DateRange } from '@/components/types';
+
+const KEY = (propertyId: string) => `blackouts:${propertyId}`;
+
+export function getBlackouts(propertyId: string): DateRange[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(KEY(propertyId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (r): r is DateRange => typeof r?.start === 'string' && typeof r?.end === 'string'
+      );
+    }
+  } catch {
+    // ignore
+  }
+  return [];
+}
+
+export function saveBlackouts(propertyId: string, ranges: DateRange[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(KEY(propertyId), JSON.stringify(ranges));
+}
+
+// TODO: Replace with Supabase table "blackouts" later.


### PR DESCRIPTION
## Summary
- fetch and parse ICS bookings and owner blackouts with timezone normalization
- merge date ranges and surface via new availability API
- enhance calendar UI with owner blackout panel and new styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c07602c1cc8328877db51a26cb6075