### PR TITLE
refactor: remove date-fns dependency

### DIFF
--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -3,8 +3,14 @@
 import { useState, useEffect, ChangeEvent, useCallback } from 'react';
 import type { AvailabilityFeed, DateRange } from './types';
 import OwnerBlackoutsPanel from './OwnerBlackoutsPanel';
-import { formatInTimeZone, utcToZonedTime } from 'date-fns-tz';
-import { startOfMonth, addMonths, getDaysInMonth, addDays } from 'date-fns';
+import {
+  formatInTimeZone,
+  utcToZonedTime,
+  startOfMonth,
+  addMonths,
+  getDaysInMonth,
+  addDays,
+} from '../lib/date';
 
 export type Props = {
   propertyId: string;

--- a/components/utils/tzNormalize.ts
+++ b/components/utils/tzNormalize.ts
@@ -1,5 +1,11 @@
-import { parse, format, startOfDay, addDays } from 'date-fns';
-import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
+import {
+  parse,
+  format,
+  startOfDay,
+  addDays,
+  utcToZonedTime,
+  zonedTimeToUtc,
+} from '../../lib/date';
 import type { DateRange, ICSRawEvent } from '../types';
 
 function parseDate(value: string, tz: string): Date {

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,60 @@
+export function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+export function addMonths(date: Date, amount: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + amount, date.getDate());
+}
+
+export function getDaysInMonth(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+}
+
+export function addDays(date: Date, amount: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + amount);
+  return d;
+}
+
+export function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function format(date: Date, fmt: string): string {
+  if (fmt === 'yyyy-MM-dd') {
+    return date.toISOString().slice(0, 10);
+  }
+  throw new Error(`Unsupported format: ${fmt}`);
+}
+
+export function formatInTimeZone(date: Date, timeZone: string, fmt: string): string {
+  if (fmt === 'yyyy-MM-dd') {
+    return new Intl.DateTimeFormat('en-CA', { timeZone }).format(date);
+  }
+  throw new Error(`Unsupported format: ${fmt}`);
+}
+
+export function utcToZonedTime(date: Date, timeZone: string): Date {
+  const inv = new Date(date.toLocaleString('en-US', { timeZone }));
+  const diff = date.getTime() - inv.getTime();
+  return new Date(date.getTime() - diff);
+}
+
+export function zonedTimeToUtc(date: Date, timeZone: string): Date {
+  const inv = new Date(date.toLocaleString('en-US', { timeZone }));
+  const diff = inv.getTime() - date.getTime();
+  return new Date(date.getTime() - diff);
+}
+
+export function parse(value: string, fmt: string, _ref: Date): Date {
+  if (fmt === 'yyyyMMdd') {
+    const year = Number(value.slice(0, 4));
+    const month = Number(value.slice(4, 6)) - 1;
+    const day = Number(value.slice(6, 8));
+    return new Date(year, month, day);
+  }
+  if (fmt === "yyyyMMdd'T'HHmmssX") {
+    return new Date(value);
+  }
+  throw new Error(`Unsupported parse format: ${fmt}`);
+}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.2",
-    "date-fns": "^2.0.0",
-    "date-fns-tz": "^2.0.0"
+    "next": "15.5.2"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- remove external date-fns libraries and use lightweight in-house helpers
- implement basic date utility functions for calendar and timezone handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c16e9b15d48328bbb40bf8d4d4dbc1