### PR TITLE
fix book page params typing and clean up date parsing

### DIFF
--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,8 +1,12 @@
 import AvailabilityCalendar from '@/components/AvailabilityCalendar';
 import { getAvailability } from '@/lib/availabilityApi';
 
-export default function Page({ params }: { params: { slug: string } }) {
-  const propertyId = params.slug; // keep simple for now
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug: propertyId } = await params; // keep simple for now
   return (
     <>
       <h1>Availability for {propertyId}</h1>

--- a/components/utils/tzNormalize.ts
+++ b/components/utils/tzNormalize.ts
@@ -10,11 +10,11 @@ import type { DateRange, ICSRawEvent } from '../types';
 
 function parseDate(value: string, tz: string): Date {
   if (/^\d{8}$/.test(value)) {
-    const naive = parse(value, 'yyyyMMdd', new Date());
+    const naive = parse(value, 'yyyyMMdd');
     return zonedTimeToUtc(naive, tz);
   }
   // handles Z or offset via X token
-  return parse(value, "yyyyMMdd'T'HHmmssX", new Date());
+  return parse(value, "yyyyMMdd'T'HHmmssX");
 }
 
 export function normalizeICS(e: ICSRawEvent, tz: string): DateRange {

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -46,7 +46,7 @@ export function zonedTimeToUtc(date: Date, timeZone: string): Date {
   return new Date(date.getTime() - diff);
 }
 
-export function parse(value: string, fmt: string, _ref: Date): Date {
+export function parse(value: string, fmt: string): Date {
   if (fmt === 'yyyyMMdd') {
     const year = Number(value.slice(0, 4));
     const month = Number(value.slice(4, 6)) - 1;


### PR DESCRIPTION
## Summary
- fix book booking page params typing for Next.js 15
- remove unused parse arg and update callers

## Testing
- `npx next build` *(fails: 403 Forbidden when fetching next)*

------
https://chatgpt.com/codex/tasks/task_e_68c1870bac80832885678630e81ac487