### PR TITLE
Fix booking page param type for Next.js 15

### DIFF
--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,11 +1,15 @@
 import AvailabilityCalendar from '@/components/AvailabilityCalendar';
 import { getAvailability } from '@/lib/availabilityApi';
 
-export default async function Page({
-  params,
-}: {
+interface BookPageProps {
   params: Promise<{ slug: string }>;
-}) {
+  /**
+   * @deprecated searchParams are unused for booking pages.
+   */
+  searchParams?: Promise<Record<string, string | string[]>>;
+}
+
+export default async function Page({ params }: BookPageProps) {
   const { slug: propertyId } = await params; // keep simple for now
   return (
     <>


### PR DESCRIPTION
## Summary
- model `params` as an async object on the booking page

## Testing
- `CI=1 npx --no-install next build`

------
https://chatgpt.com/codex/tasks/task_e_68c443ce682c8328bc6601c9a3bd5d5a