### PR TITLE
fix: static book page

### DIFF
--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,5 +1,5 @@
 import AvailabilityCalendar from '@/components/AvailabilityCalendar';
-import { getAvailability } from '@/lib/availabilityApi';
+import { properties } from '@/lib/properties';
 
 interface BookPageProps {
   params: Promise<{ slug: string }>;
@@ -17,9 +17,12 @@ export default async function Page({ params }: BookPageProps) {
       <AvailabilityCalendar
         propertyId={propertyId}
         timezone="America/New_York"
-        fetchAvailability={getAvailability}
         showOwnerPanel={false} // set true temporarily to test blackouts
       />
     </>
   );
+}
+
+export function generateStaticParams() {
+  return properties.map(({ slug }) => ({ slug }));
 }

--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -11,11 +11,16 @@ import {
   getDaysInMonth,
   addDays,
 } from '../lib/date';
+import { getAvailability } from '@/lib/availabilityApi';
 
 export type Props = {
   propertyId: string;
   timezone: string;
-  fetchAvailability: (args: { propertyId: string; start?: string; end?: string }) => Promise<AvailabilityFeed>;
+  fetchAvailability?: (args: {
+    propertyId: string;
+    start?: string;
+    end?: string;
+  }) => Promise<AvailabilityFeed>;
   showOwnerPanel?: boolean; // default false
 };
 
@@ -23,7 +28,12 @@ function inRanges(iso: string, ranges: DateRange[]): boolean {
   return ranges.some((r) => r.start <= iso && iso < r.end);
 }
 
-export default function AvailabilityCalendar({ propertyId, timezone, fetchAvailability, showOwnerPanel = false }: Props) {
+export default function AvailabilityCalendar({
+  propertyId,
+  timezone,
+  fetchAvailability = getAvailability,
+  showOwnerPanel = false,
+}: Props) {
   const [month, setMonth] = useState(() => utcToZonedTime(new Date(), timezone));
   const [feed, setFeed] = useState<AvailabilityFeed>({ property_id: propertyId, booked: [], blackouts: [], min_nights: 1 });
 


### PR DESCRIPTION
## Summary
- add static params for property booking pages
- avoid passing server functions to client calendar component

## Testing
- `npx --no-install next build`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c456c74d348328a6f60a62754bf699