### PR TITLE
Fix availability calendar and restore booking page

### DIFF
--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { getAvailability } from '@/lib/availabilityApi';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const propertyId = searchParams.get('propertyId');
+  const start = searchParams.get('start') ?? undefined;
+  const end = searchParams.get('end') ?? undefined;
+
+  if (!propertyId) {
+    return NextResponse.json({ error: 'propertyId required' }, { status: 400 });
+  }
+
+  const feed = await getAvailability({ propertyId, start, end });
+  return NextResponse.json(feed);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
   --color-secondary: #60A5FA; /* Soft Blue */
   --color-bg-light: #F8FAFC; /* Blue-tinted white */
   --color-section-bg: #E0F2FE; /* Pale Blue */
-  --color-text-primary: #033b88; /* Neutral Gray-Black */
+  --color-text-primary: var(--color-primary); /* Match body text to primary */
   --color-text-secondary: #4B5563; /* Medium Gray */
   --layout-max-width: 1200px;
   --brand: var(--color-accent);

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -2,15 +2,11 @@ import AvailabilityCalendar from '@/components/AvailabilityCalendar';
 import { properties } from '@/lib/properties';
 
 interface BookPageProps {
-  params: Promise<{ slug: string }>;
-  /**
-   * @deprecated searchParams are unused for booking pages.
-   */
-  searchParams?: Promise<Record<string, string | string[]>>;
+  params: { slug: string };
 }
 
-export default async function Page({ params }: BookPageProps) {
-  const { slug: propertyId } = await params; // keep simple for now
+export default function Page({ params }: BookPageProps) {
+  const { slug: propertyId } = params;
   return (
     <>
       <h1>Availability for {propertyId}</h1>

--- a/app/properties/[slug]/page.tsx
+++ b/app/properties/[slug]/page.tsx
@@ -2,13 +2,12 @@ import { notFound } from 'next/navigation';
 import PropertyDetailClient from './PropertyDetailClient';
 import { getPropertyBySlug, properties } from '@/lib/properties';
 
-export default async function PropertyDetail({
+export default function PropertyDetail({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
-  const property = getPropertyBySlug(slug);
+  const property = getPropertyBySlug(params.slug);
   if (!property) return notFound();
   return <PropertyDetailClient property={property} />;
 }

--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -11,7 +11,6 @@ import {
   getDaysInMonth,
   addDays,
 } from '../lib/date';
-import { getAvailability } from '@/lib/availabilityApi';
 
 export type Props = {
   propertyId: string;
@@ -31,7 +30,16 @@ function inRanges(iso: string, ranges: DateRange[]): boolean {
 export default function AvailabilityCalendar({
   propertyId,
   timezone,
-  fetchAvailability = getAvailability,
+  fetchAvailability = async ({ propertyId, start, end }) => {
+    const params = new URLSearchParams({ propertyId });
+    if (start) params.set('start', start);
+    if (end) params.set('end', end);
+    const res = await fetch(`/api/availability?${params.toString()}`);
+    if (!res.ok) {
+      throw new Error('Failed to load availability');
+    }
+    return res.json();
+  },
   showOwnerPanel = false,
 }: Props) {
   const [month, setMonth] = useState(() => utcToZonedTime(new Date(), timezone));


### PR DESCRIPTION
## Summary
- Serve availability data via a server-side API route and load it in the calendar
- Restore the booking page routing and use primary color for body text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c45bcd60748328bc543ae00ca74825