### PR TITLE
Fix availability API route dynamic rendering

### DIFF
--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { getAvailability } from '@/lib/availabilityApi';
 
-export const dynamic = 'force-static';
+// This route reads query parameters at request time, so it must be rendered
+// dynamically rather than statically during the build.
+export const dynamic = 'force-dynamic';
 export const revalidate = 3600; // regenerate every hour
 
 export async function GET(req: Request) {


### PR DESCRIPTION
## Summary
- ensure availability API route is handled dynamically to avoid static build failure

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npx --no-install next build`


------
https://chatgpt.com/codex/tasks/task_e_68c4820ecdec83288c16edbf9ba06b43