### PR TITLE
Make end date exclusive when checking calendar availability

### DIFF
--- a/components/AvailabilityCalendar.tsx
+++ b/components/AvailabilityCalendar.tsx
@@ -11,7 +11,7 @@ export interface AvailabilityCalendarProps {
 function inRange(date: Date, range: DateRange): boolean {
   const start = new Date(range.start);
   const end = new Date(range.end);
-  return date >= start && date <= end;
+  return date >= start && date < end;
 }
 
 export function AvailabilityCalendar({ data }: AvailabilityCalendarProps): ReactElement {


### PR DESCRIPTION
## Summary
- treat availability date ranges as having an exclusive end when determining booked days

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c891e7b08c83289a1757bb8ee79175