### PR TITLE
Switch site to server-side rendering

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://stromanproperties.com'),
   title: 'Stroman Properties',

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -2,16 +2,16 @@ import { notFound } from 'next/navigation';
 import Header from '@/components/Header';
 import { AvailabilityCalendar } from '@/components/AvailabilityCalendar';
 import defaultAvailability from '@/lib/availability.json';
-import { getPropertyBySlug, properties } from '@/lib/properties';
+import { getPropertyBySlug } from '@/lib/properties';
 import { fetchAvailabilityFromIcal } from '@/lib/airbnb';
 import type { AvailabilityData } from '@/lib/availability';
 
 export default async function BookPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
+  const { slug } = params;
   const property = getPropertyBySlug(slug);
   if (!property) return notFound();
 
@@ -33,8 +33,4 @@ export default async function BookPage({
       </section>
     </>
   );
-}
-
-export function generateStaticParams() {
-  return properties.map(({ slug }) => ({ slug }));
 }

--- a/app/properties/[slug]/page.tsx
+++ b/app/properties/[slug]/page.tsx
@@ -1,18 +1,14 @@
 import { notFound } from 'next/navigation';
 import PropertyDetailClient from './PropertyDetailClient';
-import { getPropertyBySlug, properties } from '@/lib/properties';
+import { getPropertyBySlug } from '@/lib/properties';
 
-export default async function PropertyDetail({
+export default function PropertyDetail({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }) {
-  const { slug } = await params;
+  const { slug } = params;
   const property = getPropertyBySlug(slug);
   if (!property) return notFound();
   return <PropertyDetailClient property={property} />;
-}
-
-export function generateStaticParams() {
-  return properties.map(({ slug }) => ({ slug }));
 }

--- a/lib/airbnb.ts
+++ b/lib/airbnb.ts
@@ -8,7 +8,7 @@ export async function fetchAvailabilityFromIcal(
   url: string,
   propertyId: string,
 ): Promise<AvailabilityData> {
-  const res = await fetch(url);
+  const res = await fetch(url, { cache: 'no-store' });
   if (!res.ok) {
     throw new Error(`Failed to fetch iCal: ${res.status}`);
   }


### PR DESCRIPTION
## Summary
- force the root layout to render dynamically so the entire app runs server-side
- remove static parameter generation from the property detail and booking routes so they render at request time
- disable caching when fetching Airbnb calendars to keep the booking data fresh

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf024cb8008328bc542b9862ad203d