### PR TITLE
Remove fallback availability sample ranges

### DIFF
--- a/lib/availability.json
+++ b/lib/availability.json
@@ -1,11 +1,6 @@
 {
   "property_id": "ashburn-estate",
-  "booked": [
-    {"start":"2025-09-12","end":"2025-09-15"},
-    {"start":"2025-10-01","end":"2025-10-05"}
-  ],
-  "blackouts": [
-    {"start":"2025-11-20","end":"2025-11-23","reason":"Owner"}
-  ],
+  "booked": [],
+  "blackouts": [],
   "min_nights": 2
 }


### PR DESCRIPTION
## Summary
- remove the sample booked and blackout date ranges from the fallback availability JSON so the UI only shows dates from the live feed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1d08a3f48328ad8a2db430606340