### PR TITLE
Add Airbnb calendar sync pipeline

### DIFF
--- a/app/api/availability/route.ts
+++ b/app/api/availability/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { fetchAllCalendarBlocks } from '@/lib/calendarBlocks';
+import { logger } from '@/lib/logging';
+
+const CACHE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+export async function GET() {
+  try {
+    const blocks = await fetchAllCalendarBlocks();
+    return NextResponse.json(blocks, { headers: CACHE_HEADERS });
+  } catch (error) {
+    logger.error('Failed to load availability', error);
+    return NextResponse.json(
+      { error: 'Failed to load availability' },
+      { status: 500, headers: CACHE_HEADERS },
+    );
+  }
+}
+

--- a/app/api/cron/airbnb-sync/route.ts
+++ b/app/api/cron/airbnb-sync/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { syncAirbnbCalendar } from '@/lib/airbnbCalendar';
+import { logger } from '@/lib/logging';
+import { sendFailureNotification } from '@/lib/notifications';
+
+const CACHE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    logger.warn('CRON_SECRET is not configured');
+    return false;
+  }
+  const provided = request.headers.get('x-cron-secret');
+  return provided === secret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401, headers: CACHE_HEADERS });
+  }
+
+  try {
+    const result = await syncAirbnbCalendar({ deleteMissing: true });
+    logger.info('Airbnb calendar sync completed', result);
+    return NextResponse.json(result, { headers: CACHE_HEADERS });
+  } catch (error) {
+    logger.error('Airbnb calendar sync failed', error);
+    await sendFailureNotification({
+      subject: 'Airbnb calendar sync failed',
+      body: `Airbnb sync failed with error: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return NextResponse.json(
+      { error: 'Airbnb calendar sync failed' },
+      { status: 500, headers: CACHE_HEADERS },
+    );
+  }
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,8 @@
   --available: #ffffff;
   --booked: #ffe0e0;
   --owner: #fff4d6;
+  --internal-confirmed: #d1fae5;
+  --internal-blocked: #e5e7eb;
   --brand: var(--color-accent);
 }
 
@@ -853,6 +855,42 @@ button:hover,
 
 .availability-calendar .day.owner {
   background: var(--owner);
+}
+
+.availability-calendar .day.external {
+  background: var(--booked);
+}
+
+.availability-calendar .day.pending {
+  background: var(--owner);
+}
+
+.availability-calendar .day.confirmed {
+  background: var(--internal-confirmed);
+}
+
+.availability-calendar .day.blocked {
+  background: var(--internal-blocked);
+}
+
+.availability-calendar .availability-error {
+  grid-column: 1 / -1;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background: var(--booked);
+  border-radius: 4px;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.availability-calendar .availability-loading {
+  grid-column: 1 / -1;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  background: var(--owner);
+  border-radius: 4px;
+  text-align: center;
+  font-size: 0.9rem;
 }
 
 .availability-calendar .day[aria-disabled="true"] {

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,10 +1,7 @@
 import { notFound } from 'next/navigation';
 import Header from '@/components/Header';
 import { AvailabilityCalendar } from '@/components/AvailabilityCalendar';
-import defaultAvailability from '@/lib/availability.json';
 import { getPropertyBySlug } from '@/lib/properties';
-import { fetchAvailabilityFromIcal } from '@/lib/airbnb';
-import type { AvailabilityData } from '@/lib/availability';
 
 export default async function BookPage({
   params,
@@ -15,21 +12,12 @@ export default async function BookPage({
   const property = getPropertyBySlug(slug);
   if (!property) return notFound();
 
-  let availability: AvailabilityData = defaultAvailability;
-  if (property.icalUrl) {
-    try {
-      availability = await fetchAvailabilityFromIcal(property.icalUrl, property.slug);
-    } catch (err) {
-      console.error('Failed to fetch iCal availability', err);
-    }
-  }
-
   return (
     <>
       <Header logo="transparent" contact />
       <section className="book-page">
         <h1>Book {property.title}</h1>
-        <AvailabilityCalendar data={availability} />
+        <AvailabilityCalendar />
       </section>
     </>
   );

--- a/lib/airbnbCalendar.ts
+++ b/lib/airbnbCalendar.ts
@@ -1,0 +1,327 @@
+import { fetchAirbnbCalendarBlocks, insertCalendarBlocks, updateCalendarBlock, updateCalendarBlocks, deleteCalendarBlocks, type CalendarBlockRecord } from '@/lib/calendarBlocks';
+
+interface ParsedEvent {
+  uid: string;
+  startDate: string;
+  endDate: string;
+}
+
+interface RawEvent {
+  lines: string[];
+}
+
+const DATE_ONLY_VALUE = 'DATE';
+
+function unfoldLines(ics: string): string[] {
+  const rawLines = ics.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  const lines: string[] = [];
+  for (const line of rawLines) {
+    if (!line) continue;
+    if (line.startsWith(' ') || line.startsWith('\t')) {
+      if (lines.length === 0) {
+        continue;
+      }
+      lines[lines.length - 1] += line.slice(1);
+    } else {
+      lines.push(line.trim());
+    }
+  }
+  return lines;
+}
+
+function extractEvents(lines: string[]): RawEvent[] {
+  const events: RawEvent[] = [];
+  let current: string[] | null = null;
+  for (const line of lines) {
+    if (line === 'BEGIN:VEVENT') {
+      current = [];
+    } else if (line === 'END:VEVENT') {
+      if (current) {
+        events.push({ lines: current });
+        current = null;
+      }
+    } else if (current) {
+      current.push(line);
+    }
+  }
+  return events;
+}
+
+function formatDateOnly(value: string): string {
+  if (!/^\d{8}$/.test(value)) {
+    throw new Error(`Invalid date value: ${value}`);
+  }
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+function formatDateInTimeZone(date: Date, timeZone: string): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.formatToParts(date);
+  const year = parts.find((p) => p.type === 'year')?.value;
+  const month = parts.find((p) => p.type === 'month')?.value;
+  const day = parts.find((p) => p.type === 'day')?.value;
+  if (!year || !month || !day) {
+    throw new Error('Failed to format date in timezone');
+  }
+  return `${year}-${month}-${day}`;
+}
+
+function normalizeDateTime(value: string, timezone: string): string {
+  if (/^\d{8}$/.test(value)) {
+    return formatDateOnly(value);
+  }
+  let working = value;
+  if (/^\d{8}T\d{6}$/.test(working)) {
+    working = `${working}Z`;
+  }
+  if (/^\d{8}T\d{6}Z$/.test(working)) {
+    const iso = `${working.slice(0, 4)}-${working.slice(4, 6)}-${working.slice(6, 8)}T${working.slice(9, 11)}:${working.slice(11, 13)}:${working.slice(13, 15)}Z`;
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+      throw new Error(`Invalid date-time value: ${value}`);
+    }
+    return formatDateInTimeZone(date, timezone);
+  }
+  throw new Error(`Unsupported date value: ${value}`);
+}
+
+function parsePropertyLine(line: string): { name: string; params: Record<string, string>; value: string } | null {
+  const idx = line.indexOf(':');
+  if (idx === -1) return null;
+  const left = line.slice(0, idx);
+  const value = line.slice(idx + 1);
+  const parts = left.split(';');
+  const name = parts[0];
+  const params: Record<string, string> = {};
+  for (let i = 1; i < parts.length; i += 1) {
+    const [key, val] = parts[i].split('=');
+    if (key && val) {
+      params[key.toUpperCase()] = val;
+    }
+  }
+  return { name: name.toUpperCase(), params, value };
+}
+
+function parseEvent(raw: RawEvent, timezone: string): ParsedEvent | null {
+  let uid: string | null = null;
+  let start: string | null = null;
+  let end: string | null = null;
+  for (const line of raw.lines) {
+    const property = parsePropertyLine(line);
+    if (!property) continue;
+    const { name, params, value } = property;
+    if (name === 'UID') {
+      uid = value.trim();
+    } else if (name === 'DTSTART') {
+      try {
+        if (params.VALUE === DATE_ONLY_VALUE) {
+          start = formatDateOnly(value.trim());
+        } else {
+          start = normalizeDateTime(value.trim(), timezone);
+        }
+      } catch (error) {
+        console.error('Failed to parse DTSTART', error);
+        return null;
+      }
+    } else if (name === 'DTEND') {
+      try {
+        if (params.VALUE === DATE_ONLY_VALUE) {
+          end = formatDateOnly(value.trim());
+        } else {
+          end = normalizeDateTime(value.trim(), timezone);
+        }
+      } catch (error) {
+        console.error('Failed to parse DTEND', error);
+        return null;
+      }
+    }
+  }
+  if (!uid || !start || !end) {
+    return null;
+  }
+  return { uid, startDate: start, endDate: end };
+}
+
+export async function fetchAirbnbEventsFromIcs(): Promise<ParsedEvent[]> {
+  const url = process.env.AIRBNB_ICS_URL;
+  if (!url) {
+    throw new Error('AIRBNB_ICS_URL is not set');
+  }
+  const timezone = process.env.PROPERTY_TIMEZONE;
+  if (!timezone) {
+    throw new Error('PROPERTY_TIMEZONE is not set');
+  }
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Failed to download Airbnb calendar (${response.status})`);
+  }
+  const ics = await response.text();
+  const lines = unfoldLines(ics);
+  const events = extractEvents(lines)
+    .map((event) => parseEvent(event, timezone))
+    .filter((event): event is ParsedEvent => event !== null);
+  return events;
+}
+
+export interface SyncOptions {
+  deleteMissing?: boolean;
+  now?: string;
+}
+
+export interface SyncResult {
+  inserted: number;
+  updated: number;
+  deleted: number;
+  unchanged: number;
+}
+
+export async function syncAirbnbCalendar(options: SyncOptions = {}): Promise<SyncResult> {
+  const events = await fetchAirbnbEventsFromIcs();
+  const existing = await fetchAirbnbCalendarBlocks();
+  const now = options.now ?? new Date().toISOString();
+
+  const existingByUid = new Map<string, CalendarBlockRecord>();
+  for (const record of existing) {
+    if (record.external_ref) {
+      existingByUid.set(record.external_ref, record);
+    }
+  }
+
+  const toInsert: {
+    source: string;
+    status: string;
+    start_date: string;
+    end_date: string;
+    external_ref: string;
+    last_sync_at: string;
+  }[] = [];
+  const toUpdate: { id: string; start_date: string; end_date: string }[] = [];
+  const matchedIds = new Set<string>();
+  const unchangedIds = new Set<string>();
+
+  for (const event of events) {
+    const match = existingByUid.get(event.uid);
+    if (!match) {
+      toInsert.push({
+        source: 'airbnb_ics',
+        status: 'confirmed',
+        start_date: event.startDate,
+        end_date: event.endDate,
+        external_ref: event.uid,
+        last_sync_at: now,
+      });
+      continue;
+    }
+
+    matchedIds.add(match.id);
+    if (match.start_date !== event.startDate || match.end_date !== event.endDate) {
+      toUpdate.push({ id: match.id, start_date: event.startDate, end_date: event.endDate });
+    } else {
+      unchangedIds.add(match.id);
+    }
+  }
+
+  await insertCalendarBlocks(toInsert);
+
+  for (const update of toUpdate) {
+    await updateCalendarBlock(update.id, {
+      start_date: update.start_date,
+      end_date: update.end_date,
+      last_sync_at: now,
+    });
+  }
+
+  if (unchangedIds.size > 0) {
+    await updateCalendarBlocks(Array.from(unchangedIds), { last_sync_at: now });
+  }
+
+  let deleted = 0;
+  if (options.deleteMissing) {
+    const toDelete = existing
+      .filter((record) => record.external_ref && !matchedIds.has(record.id))
+      .map((record) => record.id);
+    if (toDelete.length) {
+      await deleteCalendarBlocks(toDelete);
+      deleted = toDelete.length;
+    }
+  }
+
+  return {
+    inserted: toInsert.length,
+    updated: toUpdate.length,
+    deleted,
+    unchanged: unchangedIds.size,
+  };
+}
+
+export async function ingestAirbnbCalendar(): Promise<{ inserted: number; updated: number; skipped: number }> {
+  const events = await fetchAirbnbEventsFromIcs();
+  const existing = await fetchAirbnbCalendarBlocks();
+  const now = new Date().toISOString();
+  const existingByUid = new Map<string, CalendarBlockRecord>();
+  for (const record of existing) {
+    if (record.external_ref) {
+      existingByUid.set(record.external_ref, record);
+    }
+  }
+
+  const insertPayload = [] as {
+    source: string;
+    status: string;
+    start_date: string;
+    end_date: string;
+    external_ref: string;
+    last_sync_at: string;
+  }[];
+  const updates: { id: string; start_date: string; end_date: string }[] = [];
+  let skipped = 0;
+
+  for (const event of events) {
+    const match = existingByUid.get(event.uid);
+    if (!match) {
+      insertPayload.push({
+        source: 'airbnb_ics',
+        status: 'confirmed',
+        start_date: event.startDate,
+        end_date: event.endDate,
+        external_ref: event.uid,
+        last_sync_at: now,
+      });
+    } else if (match.start_date !== event.startDate || match.end_date !== event.endDate) {
+      updates.push({ id: match.id, start_date: event.startDate, end_date: event.endDate });
+    } else {
+      skipped += 1;
+    }
+  }
+
+  await insertCalendarBlocks(insertPayload);
+  for (const update of updates) {
+    await updateCalendarBlock(update.id, {
+      start_date: update.start_date,
+      end_date: update.end_date,
+      last_sync_at: now,
+    });
+  }
+
+  if (skipped > 0) {
+    const skippedIds = existing
+      .filter((record) =>
+        record.external_ref && events.some((event) => event.uid === record.external_ref && record.start_date === event.startDate && record.end_date === event.endDate),
+      )
+      .map((record) => record.id);
+    const uniqueSkippedIds = Array.from(new Set(skippedIds));
+    await updateCalendarBlocks(uniqueSkippedIds, { last_sync_at: now });
+  }
+
+  return {
+    inserted: insertPayload.length,
+    updated: updates.length,
+    skipped,
+  };
+}
+

--- a/lib/calendarBlocks.ts
+++ b/lib/calendarBlocks.ts
@@ -1,0 +1,82 @@
+import { supabaseJson, supabaseRequest } from '@/lib/supabase/rest';
+
+export interface CalendarBlockRecord {
+  id: string;
+  source: string;
+  status: string;
+  start_date: string;
+  end_date: string;
+  external_ref: string | null;
+  last_sync_at?: string | null;
+}
+
+export type CalendarBlockResponse = Pick<
+  CalendarBlockRecord,
+  'id' | 'source' | 'status' | 'start_date' | 'end_date'
+>;
+
+export interface CalendarBlockInsert {
+  source: string;
+  status: string;
+  start_date: string;
+  end_date: string;
+  external_ref?: string | null;
+  last_sync_at?: string | null;
+}
+
+export interface CalendarBlockUpdate {
+  start_date?: string;
+  end_date?: string;
+  status?: string;
+  last_sync_at?: string | null;
+}
+
+export async function fetchAllCalendarBlocks(): Promise<CalendarBlockResponse[]> {
+  return supabaseJson<CalendarBlockResponse[]>(
+    '/calendar_blocks?select=id,source,status,start_date,end_date&order=start_date',
+  );
+}
+
+export async function fetchAirbnbCalendarBlocks(): Promise<CalendarBlockRecord[]> {
+  return supabaseJson<CalendarBlockRecord[]>(
+    '/calendar_blocks?select=id,source,status,start_date,end_date,external_ref,last_sync_at&source=eq.airbnb_ics',
+  );
+}
+
+export async function insertCalendarBlocks(blocks: CalendarBlockInsert[]): Promise<void> {
+  if (!blocks.length) return;
+  await supabaseJson('/calendar_blocks', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=merge-duplicates,return=representation' },
+    json: blocks,
+  });
+}
+
+export async function updateCalendarBlock(id: string, patch: CalendarBlockUpdate): Promise<void> {
+  await supabaseJson(`/calendar_blocks?id=eq.${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=representation' },
+    json: patch,
+  });
+}
+
+export async function updateCalendarBlocks(ids: string[], patch: CalendarBlockUpdate): Promise<void> {
+  if (!ids.length) return;
+  await supabaseJson(`/calendar_blocks?id=in.(${ids.map((id) => encodeURIComponent(id)).join(',')})`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    json: patch,
+  });
+}
+
+export async function deleteCalendarBlocks(ids: string[]): Promise<void> {
+  if (!ids.length) return;
+  await supabaseRequest(`/calendar_blocks?id=in.(${ids.map((id) => encodeURIComponent(id)).join(',')})`, {
+    method: 'DELETE',
+  }).then((response) => {
+    if (!response.ok) {
+      throw new Error(`Failed to delete calendar blocks (${response.status})`);
+    }
+  });
+}
+

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -1,0 +1,48 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+function resolveLevel(): LogLevel {
+  const raw = process.env.LOG_LEVEL?.toLowerCase();
+  if (!raw) return 'info';
+  if (raw === 'debug' || raw === 'info' || raw === 'warn' || raw === 'error') {
+    return raw;
+  }
+  return 'info';
+}
+
+const ACTIVE_LEVEL = resolveLevel();
+
+function shouldLog(level: LogLevel): boolean {
+  return LEVEL_RANK[level] >= LEVEL_RANK[ACTIVE_LEVEL];
+}
+
+function formatMessage(message: string, meta?: unknown): unknown[] {
+  if (meta === undefined) return [message];
+  return [message, meta];
+}
+
+export const logger = {
+  debug(message: string, meta?: unknown) {
+    if (!shouldLog('debug')) return;
+    console.debug(...formatMessage(message, meta));
+  },
+  info(message: string, meta?: unknown) {
+    if (!shouldLog('info')) return;
+    console.info(...formatMessage(message, meta));
+  },
+  warn(message: string, meta?: unknown) {
+    if (!shouldLog('warn')) return;
+    console.warn(...formatMessage(message, meta));
+  },
+  error(message: string, meta?: unknown) {
+    if (!shouldLog('error')) return;
+    console.error(...formatMessage(message, meta));
+  },
+};
+

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,44 @@
+import { logger } from '@/lib/logging';
+
+interface NotifyOptions {
+  subject: string;
+  body: string;
+}
+
+function getResendConfig() {
+  const apiKey = process.env.RESEND_API_KEY;
+  const to = process.env.BOOKINGS_NOTIFY_TO;
+  const from = process.env.BOOKINGS_NOTIFY_FROM ?? 'alerts@stroman-properties.com';
+  if (!apiKey || !to) return null;
+  return { apiKey, to, from };
+}
+
+export async function sendFailureNotification(options: NotifyOptions): Promise<void> {
+  const config = getResendConfig();
+  if (!config) {
+    logger.debug('Skipping failure notification because email config is missing');
+    return;
+  }
+  try {
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: config.from,
+        to: config.to,
+        subject: options.subject,
+        text: options.body,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Resend request failed (${response.status}): ${text}`);
+    }
+  } catch (error) {
+    logger.error('Failed to send failure notification', error);
+  }
+}
+

--- a/lib/supabase/rest.ts
+++ b/lib/supabase/rest.ts
@@ -1,0 +1,64 @@
+const REST_API_PATH = '/rest/v1';
+
+function getSupabaseBaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
+  }
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function getServiceRoleKey(): string {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!key) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not set');
+  }
+  return key;
+}
+
+type HeadersInitInput = HeadersInit | undefined;
+
+function buildHeaders(initHeaders: HeadersInitInput, hasBody: boolean): Headers {
+  const headers = new Headers(initHeaders ?? {});
+  const serviceKey = getServiceRoleKey();
+  headers.set('apikey', serviceKey);
+  headers.set('Authorization', `Bearer ${serviceKey}`);
+  if (hasBody && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return headers;
+}
+
+export interface SupabaseRequestOptions extends RequestInit {
+  json?: unknown;
+}
+
+export async function supabaseRequest(path: string, options: SupabaseRequestOptions = {}) {
+  const baseUrl = getSupabaseBaseUrl();
+  const url = new URL(path.startsWith('/') ? path : `/${path}`, `${baseUrl}${REST_API_PATH}`);
+  const { json, ...init } = options;
+  const body = json !== undefined ? JSON.stringify(json) : options.body;
+  const headers = buildHeaders(init.headers, body !== undefined && body !== null);
+  const response = await fetch(url.toString(), {
+    cache: 'no-store',
+    ...init,
+    body,
+    headers,
+  });
+  return response;
+}
+
+export async function supabaseJson<T>(path: string, options: SupabaseRequestOptions = {}): Promise<T> {
+  const response = await supabaseRequest(path, options);
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(
+      `Supabase request failed (${response.status} ${response.statusText}): ${text}`.trim(),
+    );
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+

--- a/package.json
+++ b/package.json
@@ -6,22 +6,24 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "ingest:airbnb": "ts-node scripts/ingest-airbnb-ics.ts"
   },
   "dependencies": {
+    "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "ts-node": "^10.9.2",
+    "typescript": "^5"
   }
 }

--- a/scripts/ingest-airbnb-ics.ts
+++ b/scripts/ingest-airbnb-ics.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ingestAirbnbCalendar } from '../lib/airbnbCalendar';
+import { logger } from '../lib/logging';
+
+function parseEnvLine(line: string): [string, string] | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  const eqIndex = trimmed.indexOf('=');
+  if (eqIndex === -1) return null;
+  const key = trimmed.slice(0, eqIndex).trim();
+  let value = trimmed.slice(eqIndex + 1).trim();
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    value = value.slice(1, -1);
+  }
+  return [key, value];
+}
+
+function loadEnvFile(filePath: string) {
+  if (!fs.existsSync(filePath)) return;
+  const contents = fs.readFileSync(filePath, 'utf8');
+  for (const line of contents.split(/\r?\n/)) {
+    const pair = parseEnvLine(line);
+    if (!pair) continue;
+    const [key, value] = pair;
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function hydrateEnv() {
+  const root = process.cwd();
+  loadEnvFile(path.join(root, '.env'));
+  loadEnvFile(path.join(root, '.env.local'));
+}
+
+async function main() {
+  hydrateEnv();
+  try {
+    const result = await ingestAirbnbCalendar();
+    logger.info('Airbnb iCal ingest complete', result);
+    console.log(
+      `Ingest complete. Inserted: ${result.inserted}, Updated: ${result.updated}, Skipped: ${result.skipped}`,
+    );
+    process.exit(0);
+  } catch (error) {
+    logger.error('Failed to ingest Airbnb calendar', error);
+    console.error('Failed to ingest Airbnb calendar:', error);
+    process.exit(1);
+  }
+}
+
+void main();
+


### PR DESCRIPTION
## Summary
- add availability API route backed by Supabase calendar blocks and cron sync endpoint with secret auth
- implement shared Supabase REST + Airbnb ICS sync utilities and a one-time ingest script
- update the booking calendar UI to consume the new API and style external vs. internal holds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d42fd950188328b996f9b38ecdd538