### PR TITLE
Adjust contact nav button hover/tap styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -70,10 +70,24 @@ nav.main-nav {
 
 .nav-links button {
   background: none;
+  background-color: transparent;
   border: none;
   color: inherit;
   cursor: pointer;
   padding: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.nav-links button:focus {
+  background: transparent;
+}
+
+.nav-links button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
 }
 
 .main-nav .nav-links a,

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -38,7 +38,9 @@ export default function Header({
           <Link href="/#about">About</Link>
           <Link href="/properties">Gallery</Link>
           {contact ? (
-            <button onClick={() => setContactOpen(true)}>Contact</button>
+            <button type="button" onClick={() => setContactOpen(true)}>
+              Contact
+            </button>
           ) : (
             <Link href="/properties/ashburn-estate/book">Book</Link>
           )}


### PR DESCRIPTION
## Summary
- prevent default browser focus/hover background from appearing on the header contact button
- ensure the button keeps accessibility by defining explicit focus-visible outline styling
- mark the button as type="button" to avoid default form behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43fff2ea083289170011cda3080e1