### PR TITLE
Add booking sidebar with hold workflow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -223,11 +223,199 @@ p, label {
 .book-page {
   max-width: var(--layout-max-width);
   margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.book-page .booking-heading {
+  text-align: center;
 }
 
 .book-page h1 {
   color: var(--color-primary);
-  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.book-page .booking-heading p {
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.booking-layout {
+  display: grid;
+  gap: 2rem;
+  align-items: start;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 900px) {
+  .booking-layout {
+    grid-template-columns: 1.4fr 1fr;
+  }
+}
+
+.booking-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.booking-sidebar .card {
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(3, 59, 136, 0.08);
+  border: none;
+}
+
+.booking-summary dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+  margin: 0;
+}
+
+.booking-summary dt {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.booking-summary dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.pricing-breakdown ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pricing-breakdown li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.pricing-breakdown li strong {
+  color: var(--color-primary);
+}
+
+.pricing-breakdown li.total {
+  border-top: 1px solid rgba(3, 59, 136, 0.1);
+  padding-top: 0.75rem;
+  font-size: 1.05rem;
+}
+
+.pricing-breakdown .estimate-note {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.booking-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.booking-form label,
+.booking-form fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.booking-form input {
+  border: 1px solid rgba(3, 59, 136, 0.3);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+}
+
+.booking-form fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.payment-methods legend {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.payment-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.payment-option input {
+  accent-color: var(--color-primary);
+}
+
+.form-warning,
+.form-error {
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+}
+
+.form-warning {
+  background: #fff4d6;
+  color: #7a5700;
+}
+
+.form-error {
+  background: #ffe0e0;
+  color: #8a1f1f;
+}
+
+.booking-form button {
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  font-size: 1rem;
+  border-radius: 999px;
+}
+
+.booking-form button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.booking-form .hold-disclaimer {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.hold-next-steps p {
+  margin-top: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.hold-next-steps strong {
+  color: var(--color-primary);
+}
+
+.hold-next-steps .payment-memo {
+  font-family: 'Courier New', monospace;
+  background: rgba(59, 130, 246, 0.1);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+}
+
+.hold-next-steps .proof-note,
+.hold-next-steps .hold-window-note {
+  font-size: 0.85rem;
 }
 
 .gallery {
@@ -857,6 +1045,8 @@ button:hover,
   align-items: center;
   justify-content: center;
   font-size: 0.875rem;
+  border-radius: 8px;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .availability-calendar .day.available {
@@ -887,6 +1077,35 @@ button:hover,
   background: var(--internal-blocked);
 }
 
+.availability-calendar .day.interactive {
+  cursor: pointer;
+  border: 1px solid rgba(3, 59, 136, 0.1);
+}
+
+.availability-calendar .day.interactive:hover,
+.availability-calendar .day.interactive:focus-visible {
+  outline: none;
+  background: rgba(59, 130, 246, 0.15);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+}
+
+.availability-calendar .day.selected,
+.availability-calendar .day.in-range {
+  background: rgba(59, 130, 246, 0.25);
+  color: var(--color-primary);
+  font-weight: 700;
+}
+
+.availability-calendar .day.selected-start,
+.availability-calendar .day.selected-end {
+  background: rgba(59, 130, 246, 0.45);
+}
+
+.availability-calendar .day.range-conflict {
+  background: rgba(239, 68, 68, 0.25);
+  color: #8a1f1f;
+}
+
 .availability-calendar .availability-error {
   grid-column: 1 / -1;
   margin-bottom: 0.5rem;
@@ -894,6 +1113,15 @@ button:hover,
   background: var(--booked);
   border-radius: 4px;
   text-align: center;
+  font-size: 0.9rem;
+}
+
+.availability-calendar .availability-selection-error {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #fff4d6;
+  color: #7a5700;
+  border-radius: 8px;
   font-size: 0.9rem;
 }
 

--- a/app/properties/[slug]/book/BookingClient.tsx
+++ b/app/properties/[slug]/book/BookingClient.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import AvailabilityCalendar, {
+  type CalendarBlock,
+  type SelectedDateRange,
+} from '@/components/AvailabilityCalendar';
+import BookingSidebar from '@/components/BookingSidebar';
+import type { Property } from '@/lib/properties';
+
+interface BookingClientProps {
+  property: Property;
+  propertyTimezone: string;
+  holdWindowHours: number;
+}
+
+function parseDateValue(value: string): number {
+  const [year, month, day] = value.split('-').map(Number);
+  return Date.UTC(year, month - 1, day);
+}
+
+function toUtcDateValue(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function rangeOverlapsBlock(
+  range: SelectedDateRange,
+  blocks: CalendarBlock[],
+): boolean {
+  if (!range.checkIn || !range.checkOut) {
+    return false;
+  }
+  const startValue = toUtcDateValue(range.checkIn);
+  const endValueExclusive = toUtcDateValue(range.checkOut) + 24 * 60 * 60 * 1000;
+  return blocks.some((block) => {
+    const blockStart = parseDateValue(block.start_date);
+    const blockEnd = parseDateValue(block.end_date);
+    return startValue < blockEnd && endValueExclusive > blockStart;
+  });
+}
+
+export default function BookingClient({
+  property,
+  propertyTimezone,
+  holdWindowHours,
+}: BookingClientProps) {
+  const [selectedRange, setSelectedRange] = useState<SelectedDateRange>({
+    checkIn: null,
+    checkOut: null,
+  });
+  const [blocks, setBlocks] = useState<CalendarBlock[]>([]);
+
+  const hasBlockedOverlap = useMemo(
+    () => rangeOverlapsBlock(selectedRange, blocks),
+    [blocks, selectedRange],
+  );
+
+  return (
+    <div className="booking-layout">
+      <AvailabilityCalendar
+        selectedRange={selectedRange}
+        onChange={setSelectedRange}
+        onBlocksChange={setBlocks}
+      />
+      <BookingSidebar
+        property={property}
+        checkIn={selectedRange.checkIn}
+        checkOut={selectedRange.checkOut}
+        hasBlockedOverlap={hasBlockedOverlap}
+        propertyTimezone={propertyTimezone}
+        holdWindowHours={holdWindowHours}
+      />
+    </div>
+  );
+}

--- a/app/properties/[slug]/book/page.tsx
+++ b/app/properties/[slug]/book/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import Header from '@/components/Header';
-import { AvailabilityCalendar } from '@/components/AvailabilityCalendar';
 import { getPropertyBySlug } from '@/lib/properties';
+import BookingClient from './BookingClient';
 
 export default async function BookPage({
   params,
@@ -11,13 +11,22 @@ export default async function BookPage({
   const { slug } = params;
   const property = getPropertyBySlug(slug);
   if (!property) return notFound();
+  const propertyTimezone = process.env.PROPERTY_TIMEZONE ?? 'UTC';
+  const holdWindowHours = Number(process.env.HOLD_WINDOW_HOURS ?? '24');
 
   return (
     <>
       <Header logo="transparent" contact />
       <section className="book-page">
-        <h1>Book {property.title}</h1>
-        <AvailabilityCalendar />
+        <div className="booking-heading">
+          <h1>Book {property.title}</h1>
+          <p>Select your travel dates, review the estimate, and start a 24-hour hold.</p>
+        </div>
+        <BookingClient
+          property={property}
+          propertyTimezone={propertyTimezone}
+          holdWindowHours={holdWindowHours}
+        />
       </section>
     </>
   );

--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { Property } from '@/lib/properties';
+
+type PaymentMethod = 'zelle' | 'venmo' | 'paypal';
+
+type HoldResponse = {
+  invoice_number: number | string;
+  hold_expires_at: string;
+};
+
+interface BookingSidebarProps {
+  property: Property;
+  checkIn: Date | null;
+  checkOut: Date | null;
+  hasBlockedOverlap: boolean;
+  propertyTimezone: string;
+  holdWindowHours: number;
+}
+
+interface PaymentOption {
+  id: PaymentMethod;
+  label: string;
+  recipient: string;
+  instructions: string;
+}
+
+const PAYMENT_OPTIONS: PaymentOption[] = [
+  {
+    id: 'zelle',
+    label: 'Zelle',
+    recipient: 'payments@stromanproperties.com',
+    instructions: 'Send via your banking app to Stroman Properties. Include the memo so we can match your transfer quickly.',
+  },
+  {
+    id: 'venmo',
+    label: 'Venmo',
+    recipient: '@StromanProperties',
+    instructions: 'Open Venmo and send to @StromanProperties. Use the memo exactly and add your stay dates in the notes.',
+  },
+  {
+    id: 'paypal',
+    label: 'PayPal',
+    recipient: 'paypal.me/stromanproperties',
+    instructions: 'Visit paypal.me/stromanproperties and submit the total as “Friends & Family” when possible to avoid fees.',
+  },
+];
+
+interface FormState {
+  fullName: string;
+  email: string;
+  phone: string;
+  paymentMethod: PaymentMethod;
+}
+
+const CURRENCY_FORMAT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+function formatDateDisplay(date: Date | null): string {
+  if (!date) return '—';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function toUtcDateValue(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function calculateNights(checkIn: Date | null, checkOut: Date | null): number {
+  if (!checkIn || !checkOut) {
+    return 0;
+  }
+  const diff = toUtcDateValue(checkOut) - toUtcDateValue(checkIn);
+  return Math.max(0, Math.round(diff / (24 * 60 * 60 * 1000)));
+}
+
+function formatMemo(
+  invoiceNumber: number | string,
+  fullName: string,
+  checkIn: Date | null,
+  checkOut: Date | null,
+): string {
+  if (!checkIn || !checkOut) {
+    return `Invoice ${invoiceNumber}`;
+  }
+  const parts = fullName.trim().split(/\s+/);
+  const lastName = parts.length > 1 ? parts[parts.length - 1] : parts[0] ?? '';
+  const start = new Intl.DateTimeFormat('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+  }).format(checkIn);
+  const stayEnd = new Date(checkOut);
+  stayEnd.setDate(stayEnd.getDate() - 1);
+  const end = new Intl.DateTimeFormat('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+  }).format(stayEnd);
+  return `Invoice ${invoiceNumber} / ${lastName || 'Guest'} / ${start}–${end}`;
+}
+
+function formatDateTimeInZone(value: string, timeZone: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone,
+  }).format(date);
+}
+
+export default function BookingSidebar({
+  property,
+  checkIn,
+  checkOut,
+  hasBlockedOverlap,
+  propertyTimezone,
+  holdWindowHours,
+}: BookingSidebarProps) {
+  const [form, setForm] = useState<FormState>({
+    fullName: '',
+    email: '',
+    phone: '',
+    paymentMethod: 'zelle',
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [holdDetails, setHoldDetails] = useState<HoldResponse | null>(null);
+  const [confirmedMethod, setConfirmedMethod] = useState<PaymentMethod | null>(null);
+
+  const nights = useMemo(() => calculateNights(checkIn, checkOut), [checkIn, checkOut]);
+
+  const pricing = useMemo(() => {
+    if (nights <= 0) {
+      return null;
+    }
+    const nightlyTotal = nights * property.nightlyRate;
+    const cleaningFee = property.cleaningFee;
+    const taxable = nightlyTotal + cleaningFee;
+    const taxes = Number((taxable * property.taxRate).toFixed(2));
+    const total = nightlyTotal + cleaningFee + taxes;
+    return {
+      nightlyTotal,
+      cleaningFee,
+      taxes,
+      total,
+    };
+  }, [nights, property.cleaningFee, property.nightlyRate, property.taxRate]);
+
+  const selectedPayment = useMemo(
+    () => PAYMENT_OPTIONS.find((option) => option.id === (confirmedMethod ?? form.paymentMethod)),
+    [confirmedMethod, form.paymentMethod],
+  );
+
+  const isRangeSelected = Boolean(checkIn && checkOut && nights > 0);
+  const isFormComplete = Boolean(form.fullName && form.email && form.phone && isRangeSelected);
+  const isSubmitDisabled =
+    !isFormComplete || hasBlockedOverlap || isSubmitting || Boolean(holdDetails);
+
+  const memoText = holdDetails
+    ? formatMemo(holdDetails.invoice_number, form.fullName, checkIn, checkOut)
+    : null;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitDisabled || !checkIn || !checkOut) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/bookings/holds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          property_slug: property.slug,
+          check_in: checkIn.toISOString(),
+          check_out: checkOut.toISOString(),
+          guest_name: form.fullName,
+          guest_email: form.email,
+          guest_phone: form.phone,
+          payment_method: form.paymentMethod,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`Unable to create hold (status ${response.status})`);
+      }
+      const payload = (await response.json()) as HoldResponse;
+      setHoldDetails(payload);
+      setConfirmedMethod(form.paymentMethod);
+    } catch (err) {
+      console.error(err);
+      setError('We could not start your hold. Please try again or contact us for help.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <aside className="booking-sidebar">
+      <div className="booking-summary card">
+        <h2>Your stay</h2>
+        <dl>
+          <div>
+            <dt>Check-in</dt>
+            <dd>{formatDateDisplay(checkIn)}</dd>
+          </div>
+          <div>
+            <dt>Check-out</dt>
+            <dd>{formatDateDisplay(checkOut)}</dd>
+          </div>
+          <div>
+            <dt>Nights</dt>
+            <dd>{nights || '—'}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="pricing-breakdown card">
+        <h3>Pricing estimate</h3>
+        <ul>
+          <li>
+            <span>
+              {nights > 0
+                ? `${nights} night${nights === 1 ? '' : 's'} × ${CURRENCY_FORMAT.format(property.nightlyRate)}`
+                : `Nightly rate`}
+            </span>
+            <strong>
+              {pricing ? CURRENCY_FORMAT.format(pricing.nightlyTotal) : '—'}
+            </strong>
+          </li>
+          <li>
+            <span>Cleaning fee</span>
+            <strong>
+              {pricing ? CURRENCY_FORMAT.format(pricing.cleaningFee) : '—'}
+            </strong>
+          </li>
+          <li>
+            <span>Estimated taxes</span>
+            <strong>{pricing ? CURRENCY_FORMAT.format(pricing.taxes) : '—'}</strong>
+          </li>
+          <li className="total">
+            <span>Total due</span>
+            <strong>{pricing ? CURRENCY_FORMAT.format(pricing.total) : '—'}</strong>
+          </li>
+        </ul>
+        <p className="estimate-note">
+          {pricing
+            ? 'Final total confirmed upon verification.'
+            : 'Add your dates to see an estimated total.'}
+        </p>
+      </div>
+
+      <form className="booking-form card" onSubmit={handleSubmit}>
+        <h3>Guest details</h3>
+        <label>
+          Full name
+          <input
+            type="text"
+            value={form.fullName}
+            onChange={(event) => setForm({ ...form, fullName: event.target.value })}
+            required
+            placeholder="Jamie Rivera"
+            disabled={Boolean(holdDetails)}
+          />
+        </label>
+        <label>
+          Email
+          <input
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm({ ...form, email: event.target.value })}
+            required
+            placeholder="jamie@example.com"
+            disabled={Boolean(holdDetails)}
+          />
+        </label>
+        <label>
+          Phone
+          <input
+            type="tel"
+            value={form.phone}
+            onChange={(event) => setForm({ ...form, phone: event.target.value })}
+            required
+            placeholder="(555) 555-1234"
+            disabled={Boolean(holdDetails)}
+          />
+        </label>
+
+        <fieldset className="payment-methods" disabled={Boolean(holdDetails)}>
+          <legend>Preferred payment</legend>
+          {PAYMENT_OPTIONS.map((option) => (
+            <label key={option.id} className="payment-option">
+              <input
+                type="radio"
+                name="payment-method"
+                value={option.id}
+                checked={form.paymentMethod === option.id}
+                onChange={() => setForm({ ...form, paymentMethod: option.id })}
+              />
+              <span>{option.label}</span>
+            </label>
+          ))}
+        </fieldset>
+
+        {hasBlockedOverlap ? (
+          <div className="form-warning" role="alert">
+            Selected dates conflict with an existing booking. Choose different nights to continue.
+          </div>
+        ) : null}
+        {error ? (
+          <div className="form-error" role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        <button type="submit" disabled={isSubmitDisabled}>
+          {isSubmitting ? 'Creating hold…' : holdDetails ? 'Hold created' : 'Start 24-hour hold'}
+        </button>
+        <p className="hold-disclaimer">Soft-held for 24 hours. Unpaid holds auto-expire.</p>
+      </form>
+
+      {holdDetails && selectedPayment ? (
+        <div className="hold-next-steps card">
+          <h3>Next steps</h3>
+          <p>
+            Invoice <strong>{holdDetails.invoice_number}</strong> is reserved until{' '}
+            <strong>{formatDateTimeInZone(holdDetails.hold_expires_at, propertyTimezone)}</strong>.
+          </p>
+          <p>
+            Send the total via <strong>{selectedPayment.label}</strong> to{' '}
+            <strong>{selectedPayment.recipient}</strong>.
+          </p>
+          <p>{selectedPayment.instructions}</p>
+          {memoText ? (
+            <p className="payment-memo">
+              Memo: <strong>{memoText}</strong>
+            </p>
+          ) : null}
+          <p className="proof-note">
+            Upload payment proof (screenshot or transaction ID) once sent so we can confirm your stay quickly.
+          </p>
+          <p className="hold-window-note">
+            Holds last {holdWindowHours} hours unless confirmed. Reach out if you need more time or have questions.
+          </p>
+        </div>
+      ) : null}
+    </aside>
+  );
+}

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -18,6 +18,9 @@ export type Property = {
   bedrooms: number;
   beds: number;
   bathrooms: number;
+  nightlyRate: number;
+  cleaningFee: number;
+  taxRate: number;
   icalUrl?: string;
 };
 
@@ -32,6 +35,9 @@ export const properties: Property[] = [
     bedrooms: 3,
     beds: 4,
     bathrooms: 3.5,
+    nightlyRate: 315,
+    cleaningFee: 200,
+    taxRate: 0.1,
     rooms: [
       {
         title: 'Kitchen',


### PR DESCRIPTION
## Summary
- add a client booking flow that links the availability calendar with a new pricing and payment sidebar
- enhance the availability calendar to support selecting ranges while respecting blocked dates
- style the booking page layout and extend property data with pricing details for estimates

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package in the environment)*
- npm run build *(fails: Next.js CLI binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d466684a808328bc58f982c2b162d1