### PR TITLE
Fix Supabase storage upload body handling

### DIFF
--- a/app/api/bookings/proof/route.ts
+++ b/app/api/bookings/proof/route.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from 'crypto';
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logging';
+import { sendOwnerNotification } from '@/lib/notifications';
+import { supabaseJson, supabaseRequest } from '@/lib/supabase/rest';
+import { uploadStorageObject } from '@/lib/supabase/storage';
+
+const PROCESSORS = ['zelle', 'venmo', 'paypal', 'offline'] as const;
+type Processor = (typeof PROCESSORS)[number];
+const VALID_PROCESSORS = new Set<Processor>(PROCESSORS);
+
+type BookingRecord = {
+  id: string;
+  invoice_number: string;
+  status: string;
+  hold_expires_at: string | null;
+  payment_method: string | null;
+};
+
+type PaymentRecord = {
+  id: string;
+  booking_id: string;
+};
+
+class HttpError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function requireFormString(form: FormData, field: string): string {
+  const value = form.get(field);
+  if (typeof value !== 'string') {
+    throw new HttpError(`Missing field: ${field}`, 400);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new HttpError(`Missing field: ${field}`, 400);
+  }
+  return trimmed;
+}
+
+function optionalFormString(form: FormData, field: string): string | null {
+  const value = form.get(field);
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function sanitizeInvoiceFolder(invoice: string): string {
+  const fallback = 'invoice';
+  const cleaned = invoice.replace(/[^A-Za-z0-9_-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return cleaned || fallback;
+}
+
+function resolveExtension(filename: string): string | null {
+  const parts = filename.split('.');
+  if (parts.length < 2) return null;
+  const ext = parts.pop();
+  if (!ext) return null;
+  const safe = ext.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return safe || null;
+}
+
+function buildProofObjectPath(invoiceNumber: string, originalName: string): string {
+  const folder = sanitizeInvoiceFolder(invoiceNumber);
+  const extension = resolveExtension(originalName);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '');
+  const suffix = extension ? `.${extension}` : '';
+  return `${folder}/${timestamp}-${randomUUID()}${suffix}`;
+}
+
+function isHoldExpired(holdExpiresAt: string | null): boolean {
+  if (!holdExpiresAt) return false;
+  const expires = new Date(holdExpiresAt);
+  if (Number.isNaN(expires.getTime())) {
+    return true;
+  }
+  return expires.getTime() <= Date.now();
+}
+
+function resolveProcessor(value: string | null): Processor {
+  const normalized = (value ?? '').toLowerCase();
+  if (VALID_PROCESSORS.has(normalized as Processor)) {
+    return normalized as Processor;
+  }
+  return 'offline';
+}
+
+export async function POST(request: Request) {
+  try {
+    const form = await request.formData();
+    const invoiceNumber = requireFormString(form, 'invoice_number');
+    const payerName = requireFormString(form, 'payer_name');
+    const reference = optionalFormString(form, 'reference');
+    const note = optionalFormString(form, 'note');
+    const proof = form.get('proof');
+
+    if (!(proof instanceof File)) {
+      throw new HttpError('Proof upload is required', 400);
+    }
+    if (proof.size <= 0) {
+      throw new HttpError('Uploaded proof file is empty', 400);
+    }
+
+    const bookingRecords = await supabaseJson<BookingRecord[]>(
+      `/bookings?invoice_number=eq.${encodeURIComponent(invoiceNumber)}&select=id,invoice_number,status,hold_expires_at,payment_method&limit=1`,
+    );
+    const booking = bookingRecords?.[0];
+    if (!booking) {
+      throw new HttpError('Booking not found for this invoice', 404);
+    }
+    if (booking.status !== 'pending_hold') {
+      throw new HttpError('This booking is not awaiting payment proof', 400);
+    }
+    if (isHoldExpired(booking.hold_expires_at)) {
+      throw new HttpError('This hold has expired. Please contact us for assistance.', 400);
+    }
+
+    const paymentRecords = await supabaseJson<PaymentRecord[]>(
+      `/payments?booking_id=eq.${encodeURIComponent(booking.id)}&select=id,booking_id&limit=1`,
+    );
+    const payment = paymentRecords?.[0];
+    if (!payment) {
+      throw new HttpError('Payment record not found for this booking', 404);
+    }
+
+    const fileData = await proof.arrayBuffer();
+    const objectPath = buildProofObjectPath(invoiceNumber, proof.name);
+    const uploadResult = await uploadStorageObject({
+      bucket: 'proofs',
+      objectPath,
+      body: fileData,
+      contentType: proof.type || 'application/octet-stream',
+      upsert: true,
+    });
+
+    const processor = resolveProcessor(booking.payment_method);
+    const updatePayload = {
+      payer_name: payerName,
+      reference: reference ?? null,
+      note: note ?? null,
+      proof_file_url: uploadResult.publicUrl,
+      processor,
+      received_at: new Date().toISOString(),
+    };
+
+    const updateResponse = await supabaseRequest(
+      `/payments?id=eq.${encodeURIComponent(payment.id)}`,
+      {
+        method: 'PATCH',
+        headers: { Prefer: 'return=minimal' },
+        json: updatePayload,
+      },
+    );
+
+    if (!updateResponse.ok) {
+      const text = await updateResponse.text().catch(() => '');
+      throw new Error(`Failed to update payment record (${updateResponse.status}): ${text}`);
+    }
+
+    const emailLines = [
+      'A guest submitted payment proof.',
+      `Invoice: ${invoiceNumber}`,
+      `Payer: ${payerName}`,
+      `Processor: ${processor}`,
+      reference ? `Reference: ${reference}` : null,
+      note ? `Note: ${note}` : null,
+      `Proof URL: ${uploadResult.publicUrl}`,
+    ].filter(Boolean);
+
+    await sendOwnerNotification({
+      subject: 'Payment proof received.',
+      body: emailLines.join('\n'),
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Thanks! We received your payment proof. Owner will verify and confirm.',
+    });
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    logger.error('Failed to process payment proof upload', error);
+    return NextResponse.json({ error: 'Unable to submit payment proof' }, { status: 500 });
+  }
+}

--- a/app/bookings/[invoice]/upload-proof/page.tsx
+++ b/app/bookings/[invoice]/upload-proof/page.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import type { CSSProperties, FormEvent } from 'react';
+import { useState } from 'react';
+
+type UploadState = 'idle' | 'submitting' | 'success';
+
+interface UploadProofPageProps {
+  params: { invoice: string };
+}
+
+const containerStyle: CSSProperties = {
+  maxWidth: '640px',
+  margin: '0 auto',
+  padding: '3rem 1.5rem',
+};
+
+const cardStyle: CSSProperties = {
+  background: '#ffffff',
+  borderRadius: '0.75rem',
+  padding: '2rem',
+  boxShadow: '0 2px 12px rgba(15, 23, 42, 0.12)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.25rem',
+};
+
+const fieldsetStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.25rem',
+  border: 'none',
+  padding: 0,
+  margin: 0,
+};
+
+const labelStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  fontWeight: 600,
+};
+
+const inputStyle: CSSProperties = {
+  padding: '0.75rem 1rem',
+  borderRadius: '0.5rem',
+  border: '1px solid #d4d4d8',
+  fontSize: '1rem',
+};
+
+const helperStyle: CSSProperties = {
+  margin: 0,
+  fontSize: '0.9rem',
+  color: '#6b7280',
+  fontWeight: 400,
+};
+
+const messageStyle: CSSProperties = {
+  borderRadius: '0.5rem',
+  padding: '1rem',
+  fontSize: '0.95rem',
+  lineHeight: 1.5,
+};
+
+const successStyle: CSSProperties = {
+  ...messageStyle,
+  background: '#ecfdf5',
+  color: '#166534',
+  border: '1px solid #bbf7d0',
+};
+
+const errorStyle: CSSProperties = {
+  ...messageStyle,
+  background: '#fef2f2',
+  color: '#b91c1c',
+  border: '1px solid #fecaca',
+};
+
+const submitStyle: CSSProperties = {
+  padding: '0.85rem 1.5rem',
+  background: 'var(--color-primary)',
+  color: '#ffffff',
+  fontSize: '1rem',
+  border: 'none',
+  borderRadius: '0.5rem',
+  cursor: 'pointer',
+  fontWeight: 600,
+};
+
+export default function UploadProofPage({ params }: UploadProofPageProps) {
+  const invoiceNumber = params.invoice ?? '';
+  const [state, setState] = useState<UploadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const isSubmitting = state === 'submitting';
+  const isSuccess = state === 'success';
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const formElement = event.currentTarget;
+    const formData = new FormData(formElement);
+    formData.set('invoice_number', invoiceNumber);
+
+    const payerName = formData.get('payer_name');
+    const proof = formData.get('proof');
+
+    if (typeof payerName !== 'string' || !payerName.trim()) {
+      setError('Please share the name associated with the payment.');
+      return;
+    }
+
+    if (!(proof instanceof File) || proof.size === 0) {
+      setError('Please attach your payment screenshot or PDF before submitting.');
+      return;
+    }
+
+    setError(null);
+    setState('submitting');
+
+    try {
+      const response = await fetch('/api/bookings/proof', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        const message = payload?.error ?? `We could not upload your proof (status ${response.status}).`;
+        throw new Error(message);
+      }
+
+      formElement.reset();
+      setState('success');
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
+      setState('idle');
+    }
+  };
+
+  return (
+    <main style={containerStyle}>
+      <section style={cardStyle}>
+        <header style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <h1 style={{ margin: 0, fontSize: '2rem', color: 'var(--color-primary)' }}>Upload payment proof</h1>
+          <p style={{ margin: 0, color: 'var(--color-text-secondary)' }}>
+            Invoice <strong>{invoiceNumber}</strong>
+          </p>
+        </header>
+
+        <p style={{ margin: 0, color: 'var(--color-text-secondary)', lineHeight: 1.6 }}>
+          Thanks for sending your payment. Upload a quick screenshot or PDF of your transfer and share any transaction
+          reference details so our team can match it quickly.
+        </p>
+
+        {isSuccess && (
+          <div style={successStyle} role="status" aria-live="polite">
+            Thanks! We received your payment proof. Owner will verify and confirm.
+          </div>
+        )}
+
+        {error && (
+          <div style={errorStyle} role="alert">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} encType="multipart/form-data" style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+          <input type="hidden" name="invoice_number" value={invoiceNumber} />
+          <fieldset style={fieldsetStyle}>
+            <label style={labelStyle}>
+              Payer name
+              <input
+                type="text"
+                name="payer_name"
+                required
+                placeholder="Full name of the payer"
+                style={inputStyle}
+                disabled={isSubmitting}
+              />
+            </label>
+
+            <label style={labelStyle}>
+              Transaction reference
+              <input
+                type="text"
+                name="reference"
+                placeholder="Confirmation number or memo"
+                style={inputStyle}
+                disabled={isSubmitting}
+              />
+              <p style={helperStyle}>Include any confirmation code, memo, or handle that helps us find your transfer.</p>
+            </label>
+
+            <label style={labelStyle}>
+              Additional note
+              <textarea
+                name="note"
+                rows={4}
+                placeholder="Anything else we should know?"
+                style={{ ...inputStyle, resize: 'vertical', fontFamily: 'inherit' }}
+                disabled={isSubmitting}
+              />
+            </label>
+
+            <label style={labelStyle}>
+              Proof of payment
+              <input type="file" name="proof" accept="image/*,.pdf" required style={inputStyle} disabled={isSubmitting} />
+              <p style={helperStyle}>Upload a screenshot or PDF. JPG, PNG, HEIC, and PDF files are supported.</p>
+            </label>
+          </fieldset>
+
+          <button type="submit" style={{ ...submitStyle, opacity: isSubmitting ? 0.7 : 1 }} disabled={isSubmitting}>
+            {isSubmitting ? 'Uploading…' : 'Submit payment proof'}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -13,10 +13,10 @@ function getResendConfig() {
   return { apiKey, to, from };
 }
 
-export async function sendFailureNotification(options: NotifyOptions): Promise<void> {
+async function sendNotification(options: NotifyOptions, context: string): Promise<void> {
   const config = getResendConfig();
   if (!config) {
-    logger.debug('Skipping failure notification because email config is missing');
+    logger.debug(`Skipping ${context} notification because email config is missing`);
     return;
   }
   try {
@@ -38,7 +38,15 @@ export async function sendFailureNotification(options: NotifyOptions): Promise<v
       throw new Error(`Resend request failed (${response.status}): ${text}`);
     }
   } catch (error) {
-    logger.error('Failed to send failure notification', error);
+    logger.error(`Failed to send ${context} notification`, error);
   }
+}
+
+export async function sendFailureNotification(options: NotifyOptions): Promise<void> {
+  await sendNotification(options, 'failure');
+}
+
+export async function sendOwnerNotification(options: NotifyOptions): Promise<void> {
+  await sendNotification(options, 'owner');
 }
 

--- a/lib/supabase/rest.ts
+++ b/lib/supabase/rest.ts
@@ -1,6 +1,6 @@
 const REST_API_PATH = '/rest/v1';
 
-function getSupabaseBaseUrl(): string {
+export function getSupabaseBaseUrl(): string {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   if (!url) {
     throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set');
@@ -8,7 +8,7 @@ function getSupabaseBaseUrl(): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
-function getServiceRoleKey(): string {
+export function getServiceRoleKey(): string {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!key) {
     throw new Error('SUPABASE_SERVICE_ROLE_KEY is not set');

--- a/lib/supabase/storage.ts
+++ b/lib/supabase/storage.ts
@@ -1,0 +1,80 @@
+import { getSupabaseBaseUrl, getServiceRoleKey } from '@/lib/supabase/rest';
+
+interface UploadOptions {
+  bucket: string;
+  objectPath: string;
+  body: ArrayBuffer | Uint8Array | Buffer;
+  contentType?: string;
+  upsert?: boolean;
+}
+
+export interface UploadResult {
+  path: string;
+  publicUrl: string;
+}
+
+function cloneToArrayBuffer(view: ArrayBufferView): ArrayBuffer {
+  const buffer = new ArrayBuffer(view.byteLength);
+  const array = new Uint8Array(buffer);
+  array.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+  return buffer;
+}
+
+function toBlobBody(body: UploadOptions['body']): Blob {
+  if (body instanceof ArrayBuffer) {
+    return new Blob([body]);
+  }
+  if (ArrayBuffer.isView(body)) {
+    return new Blob([cloneToArrayBuffer(body)]);
+  }
+  throw new TypeError('Unsupported storage upload body type');
+}
+
+function buildStorageUrl(bucket: string, encodedPath: string): string {
+  const baseUrl = getSupabaseBaseUrl().replace(/\/+$/, '');
+  const cleanBucket = bucket.replace(/^\/+/, '');
+  return `${baseUrl}/storage/v1/object/${cleanBucket}/${encodedPath}`;
+}
+
+function encodePath(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+}
+
+function buildPublicUrl(bucket: string, path: string): string {
+  const baseUrl = getSupabaseBaseUrl().replace(/\/+$/, '');
+  const cleanBucket = bucket.replace(/^\/+/, '');
+  const cleanPath = path.replace(/^\/+/, '');
+  return `${baseUrl}/storage/v1/object/public/${cleanBucket}/${cleanPath}`;
+}
+
+export async function uploadStorageObject(options: UploadOptions): Promise<UploadResult> {
+  const { bucket, objectPath, body, contentType, upsert } = options;
+  const data = toBlobBody(body);
+  const encodedPath = encodePath(objectPath.replace(/^\/+/, ''));
+  const url = buildStorageUrl(bucket, encodedPath);
+  const serviceKey = getServiceRoleKey();
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': contentType ?? 'application/octet-stream',
+      'x-upsert': upsert ? 'true' : 'false',
+    },
+    body: data,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Failed to upload storage object (${response.status}): ${text}`);
+  }
+
+  return {
+    path: objectPath.replace(/^\/+/, ''),
+    publicUrl: buildPublicUrl(bucket, objectPath),
+  };
+}


### PR DESCRIPTION
## Summary
- wrap Supabase storage uploads in Blob objects so fetch receives a valid BodyInit
- add a helper to clone array buffer views before wrapping them in Blob form
- surface an explicit error when an unsupported body type is provided to the upload helper

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4700e84988328862611bd4005d0d8