### PR TITLE
Add admin booking management routes

### DIFF
--- a/app/api/admin/bookings/_shared.ts
+++ b/app/api/admin/bookings/_shared.ts
@@ -1,0 +1,207 @@
+import { logger } from '@/lib/logging';
+import type { CalendarBlockRecord } from '@/lib/calendarBlocks';
+import { deleteCalendarBlocks, updateCalendarBlocks } from '@/lib/calendarBlocks';
+import { supabaseJson, supabaseRequest } from '@/lib/supabase/rest';
+
+export class HttpError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+interface BookingRecord {
+  id: string;
+  invoice_number: string;
+  status: string;
+  hold_expires_at: string | null;
+  paid_at: string | null;
+  guest_id: string | null;
+}
+
+interface GuestRecord {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+interface PaymentRecord {
+  id: string;
+  status: string;
+}
+
+interface BookingCalendarBlock extends Pick<
+  CalendarBlockRecord,
+  'id' | 'status' | 'source' | 'start_date' | 'end_date'
+> {
+  booking_id?: string | null;
+}
+
+interface AuditMetadata {
+  [key: string]: unknown;
+}
+
+export interface AdminContext {
+  actor: string;
+}
+
+function getAdminSecret(): string {
+  const secret = process.env.ADMIN_API_SECRET;
+  if (!secret) {
+    throw new Error('ADMIN_API_SECRET is not configured');
+  }
+  return secret;
+}
+
+function extractBearer(value: string | null): string | null {
+  if (!value) return null;
+  const match = value.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  return match[1].trim();
+}
+
+export function requireAdmin(request: Request): AdminContext {
+  const secret = getAdminSecret();
+  const provided =
+    extractBearer(request.headers.get('authorization')) ??
+    request.headers.get('x-admin-secret')?.trim();
+
+  if (!provided || provided !== secret) {
+    throw new HttpError('Unauthorized', 401);
+  }
+
+  const actor = request.headers.get('x-admin-actor')?.trim() || 'admin';
+  return { actor };
+}
+
+export async function parseJsonBody<T>(request: Request): Promise<T> {
+  try {
+    return (await request.json()) as T;
+  } catch (error) {
+    logger.warn('Failed to parse JSON body for admin request', error);
+    throw new HttpError('Invalid JSON body', 400);
+  }
+}
+
+export function requireInvoiceNumber(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new HttpError('Missing invoice_number', 400);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new HttpError('Missing invoice_number', 400);
+  }
+  return trimmed;
+}
+
+export function isHoldExpired(holdExpiresAt: string | null): boolean {
+  if (!holdExpiresAt) return false;
+  const expires = new Date(holdExpiresAt);
+  if (Number.isNaN(expires.getTime())) {
+    return true;
+  }
+  return expires.getTime() <= Date.now();
+}
+
+export async function fetchBookingByInvoice(invoiceNumber: string): Promise<BookingRecord> {
+  const encoded = encodeURIComponent(invoiceNumber);
+  const records = await supabaseJson<BookingRecord[]>(
+    `/bookings?invoice_number=eq.${encoded}&select=id,invoice_number,status,hold_expires_at,paid_at,guest_id&limit=1`,
+  );
+  const booking = records?.[0];
+  if (!booking) {
+    throw new HttpError('Booking not found', 404);
+  }
+  return booking;
+}
+
+export async function fetchGuest(guestId: string | null): Promise<GuestRecord | null> {
+  if (!guestId) return null;
+  const encoded = encodeURIComponent(guestId);
+  const records = await supabaseJson<GuestRecord[]>(
+    `/guests?id=eq.${encoded}&select=id,full_name,email,phone&limit=1`,
+  );
+  return records?.[0] ?? null;
+}
+
+export async function fetchPayments(bookingId: string): Promise<PaymentRecord[]> {
+  const encoded = encodeURIComponent(bookingId);
+  return (
+    await supabaseJson<PaymentRecord[]>(
+      `/payments?booking_id=eq.${encoded}&select=id,status&order=created_at`,
+    )
+  ) ?? [];
+}
+
+async function patchSupabase(path: string, payload: Record<string, unknown>, context: string): Promise<void> {
+  const response = await supabaseRequest(path, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    json: payload,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Failed to ${context} (${response.status}): ${text}`);
+  }
+}
+
+export async function updatePayments(
+  bookingId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const encoded = encodeURIComponent(bookingId);
+  await patchSupabase(`/payments?booking_id=eq.${encoded}`, payload, 'update payment records');
+}
+
+export async function updateBooking(
+  bookingId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const encoded = encodeURIComponent(bookingId);
+  await patchSupabase(`/bookings?id=eq.${encoded}`, payload, 'update booking');
+}
+
+export async function fetchBookingBlocks(bookingId: string): Promise<BookingCalendarBlock[]> {
+  const encoded = encodeURIComponent(bookingId);
+  return (
+    await supabaseJson<BookingCalendarBlock[]>(
+      `/calendar_blocks?booking_id=eq.${encoded}&select=id,status,source,start_date,end_date`,
+    )
+  ) ?? [];
+}
+
+export async function updateCalendarBlockStatus(ids: string[], status: string): Promise<void> {
+  if (!ids.length) return;
+  await updateCalendarBlocks(ids, { status });
+}
+
+export async function removeCalendarBlocks(ids: string[]): Promise<void> {
+  if (!ids.length) return;
+  await deleteCalendarBlocks(ids);
+}
+
+export async function logAuditEvent(
+  bookingId: string,
+  action: string,
+  actor: string,
+  metadata: AuditMetadata = {},
+): Promise<void> {
+  const response = await supabaseRequest('/booking_audit_events', {
+    method: 'POST',
+    headers: { Prefer: 'return=minimal' },
+    json: {
+      booking_id: bookingId,
+      action,
+      actor,
+      metadata: Object.keys(metadata).length ? metadata : null,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Failed to log audit event (${response.status}): ${text}`);
+  }
+}

--- a/app/api/admin/bookings/cancel/route.ts
+++ b/app/api/admin/bookings/cancel/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logging';
+import { sendGuestNotification } from '@/lib/notifications';
+import {
+  HttpError,
+  fetchBookingBlocks,
+  fetchBookingByInvoice,
+  fetchGuest,
+  fetchPayments,
+  logAuditEvent,
+  parseJsonBody,
+  removeCalendarBlocks,
+  requireAdmin,
+  requireInvoiceNumber,
+  updateBooking,
+} from '../_shared';
+
+interface CancelRequestBody {
+  invoice_number?: string;
+  reason?: string;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { actor } = requireAdmin(request);
+    const body = await parseJsonBody<CancelRequestBody>(request);
+    const invoiceNumber = requireInvoiceNumber(body.invoice_number);
+    const reason = (body.reason ?? '').trim();
+
+    const booking = await fetchBookingByInvoice(invoiceNumber);
+
+    if (booking.status === 'paid') {
+      throw new HttpError('Cannot cancel a paid booking', 409);
+    }
+    if (booking.status === 'canceled') {
+      return NextResponse.json({ success: true, message: 'Booking already canceled' });
+    }
+
+    await updateBooking(booking.id, { status: 'canceled' });
+
+    const blocks = await fetchBookingBlocks(booking.id);
+    const removableIds = blocks
+      .filter((block) => block.status === 'internal_pending' || block.status === 'internal_confirmed')
+      .map((block) => block.id);
+    await removeCalendarBlocks(removableIds);
+
+    const guest = await fetchGuest(booking.guest_id);
+    if (guest?.email) {
+      const greeting = guest.full_name ? `Hi ${guest.full_name},` : 'Hello,';
+      const lines = [
+        greeting,
+        '',
+        'Your booking has been canceled per the owner\'s request.',
+        `Invoice: ${invoiceNumber}`,
+      ];
+      if (reason) {
+        lines.push('', `Reason: ${reason}`);
+      }
+      lines.push('', 'Please contact us if you have any questions.', '', 'Regards,', 'Stroman Properties');
+      await sendGuestNotification(guest.email, {
+        subject: 'Booking Canceled',
+        body: lines.join('\n'),
+      });
+    } else {
+      logger.warn('Skipping booking cancellation email because guest email is missing', {
+        bookingId: booking.id,
+      });
+    }
+
+    const payments = await fetchPayments(booking.id);
+    if (payments.length) {
+      logger.info('Payment records remain after cancellation', {
+        bookingId: booking.id,
+        paymentCount: payments.length,
+      });
+    }
+
+    await logAuditEvent(booking.id, 'booking_canceled', actor, {
+      invoice_number: invoiceNumber,
+      reason: reason || null,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    logger.error('Failed to cancel booking', error);
+    return NextResponse.json({ error: 'Unable to cancel booking' }, { status: 500 });
+  }
+}

--- a/app/api/admin/bookings/expire/route.ts
+++ b/app/api/admin/bookings/expire/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logging';
+import { sendGuestNotification } from '@/lib/notifications';
+import {
+  HttpError,
+  fetchBookingBlocks,
+  fetchBookingByInvoice,
+  fetchGuest,
+  isHoldExpired,
+  logAuditEvent,
+  parseJsonBody,
+  removeCalendarBlocks,
+  requireAdmin,
+  requireInvoiceNumber,
+  updateBooking,
+} from '../_shared';
+
+interface ExpireRequestBody {
+  invoice_number?: string;
+  force?: boolean;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { actor } = requireAdmin(request);
+    const body = await parseJsonBody<ExpireRequestBody>(request);
+    const invoiceNumber = requireInvoiceNumber(body.invoice_number);
+    const forceExpire = body.force === true;
+
+    const booking = await fetchBookingByInvoice(invoiceNumber);
+
+    if (booking.status === 'paid') {
+      throw new HttpError('Cannot expire a confirmed booking', 409);
+    }
+    if (booking.status === 'canceled') {
+      throw new HttpError('Booking has been canceled', 409);
+    }
+    if (booking.status === 'expired' && !forceExpire) {
+      return NextResponse.json({ success: true, message: 'Booking already expired' });
+    }
+
+    if (!forceExpire && !isHoldExpired(booking.hold_expires_at)) {
+      throw new HttpError('Hold has not expired yet', 409);
+    }
+
+    await updateBooking(booking.id, { status: 'expired' });
+
+    const blocks = await fetchBookingBlocks(booking.id);
+    const removableIds = blocks
+      .filter((block) => block.status === 'internal_pending' || block.status === 'pending')
+      .map((block) => block.id);
+    await removeCalendarBlocks(removableIds);
+
+    const guest = await fetchGuest(booking.guest_id);
+    if (guest?.email) {
+      const greeting = guest.full_name ? `Hi ${guest.full_name},` : 'Hello,';
+      const messageLines = [
+        greeting,
+        '',
+        'We did not receive payment in time and the temporary hold on your requested dates has expired.',
+        `Invoice: ${invoiceNumber}`,
+        '',
+        'Those dates are now available again. Please reach out if you still need assistance.',
+        '',
+        'Regards,',
+        'Stroman Properties',
+      ];
+      await sendGuestNotification(guest.email, {
+        subject: 'Booking Hold Expired',
+        body: messageLines.join('\n'),
+      });
+    } else {
+      logger.warn('Skipping hold expiration email because guest email is missing', {
+        bookingId: booking.id,
+      });
+    }
+
+    await logAuditEvent(booking.id, 'booking_expired', actor, {
+      invoice_number: invoiceNumber,
+      force: forceExpire,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    logger.error('Failed to expire booking hold', error);
+    return NextResponse.json({ error: 'Unable to expire booking hold' }, { status: 500 });
+  }
+}

--- a/app/api/admin/bookings/verify/route.ts
+++ b/app/api/admin/bookings/verify/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logging';
+import { sendGuestNotification } from '@/lib/notifications';
+import {
+  HttpError,
+  fetchBookingBlocks,
+  fetchBookingByInvoice,
+  fetchGuest,
+  fetchPayments,
+  isHoldExpired,
+  logAuditEvent,
+  parseJsonBody,
+  requireAdmin,
+  requireInvoiceNumber,
+  updateBooking,
+  updateCalendarBlockStatus,
+  updatePayments,
+} from '../_shared';
+
+interface VerifyRequestBody {
+  invoice_number?: string;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { actor } = requireAdmin(request);
+    const body = await parseJsonBody<VerifyRequestBody>(request);
+    const invoiceNumber = requireInvoiceNumber(body.invoice_number);
+
+    const booking = await fetchBookingByInvoice(invoiceNumber);
+
+    if (booking.status === 'paid') {
+      throw new HttpError('Booking already verified', 409);
+    }
+    if (booking.status === 'canceled') {
+      throw new HttpError('Booking has been canceled', 409);
+    }
+    if (booking.status === 'expired') {
+      throw new HttpError('Hold has already expired', 409);
+    }
+    if (isHoldExpired(booking.hold_expires_at)) {
+      throw new HttpError('Hold has already expired', 409);
+    }
+
+    const payments = await fetchPayments(booking.id);
+    if (!payments.length) {
+      throw new HttpError('No payment records found for this booking', 400);
+    }
+
+    const now = new Date().toISOString();
+    await updatePayments(booking.id, { status: 'verified', verified_at: now });
+    await updateBooking(booking.id, { status: 'paid', paid_at: now });
+
+    const blocks = await fetchBookingBlocks(booking.id);
+    const internalPendingIds = blocks
+      .filter((block) => block.status === 'internal_pending')
+      .map((block) => block.id);
+    const pendingIds = blocks
+      .filter((block) => block.status === 'pending')
+      .map((block) => block.id);
+
+    await Promise.all([
+      updateCalendarBlockStatus(internalPendingIds, 'internal_confirmed'),
+      updateCalendarBlockStatus(pendingIds, 'confirmed'),
+    ]);
+
+    const guest = await fetchGuest(booking.guest_id);
+    if (guest?.email) {
+      const greeting = guest.full_name ? `Hi ${guest.full_name},` : 'Hello,';
+      const messageLines = [
+        greeting,
+        '',
+        'Great news — your booking is confirmed! We have marked your payment as received.',
+        `Invoice: ${invoiceNumber}`,
+        '',
+        'We look forward to hosting you.',
+        '',
+        'Warm regards,',
+        'Stroman Properties',
+      ];
+      await sendGuestNotification(guest.email, {
+        subject: 'Booking Confirmed',
+        body: messageLines.join('\n'),
+      });
+    } else {
+      logger.warn('Skipping booking confirmation email because guest email is missing', {
+        bookingId: booking.id,
+      });
+    }
+
+    await logAuditEvent(booking.id, 'booking_verified', actor, { invoice_number: invoiceNumber });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    logger.error('Failed to verify booking hold', error);
+    return NextResponse.json({ error: 'Unable to verify booking' }, { status: 500 });
+  }
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -5,48 +5,109 @@ interface NotifyOptions {
   body: string;
 }
 
-function getResendConfig() {
-  const apiKey = process.env.RESEND_API_KEY;
-  const to = process.env.BOOKINGS_NOTIFY_TO;
-  const from = process.env.BOOKINGS_NOTIFY_FROM ?? 'alerts@stroman-properties.com';
-  if (!apiKey || !to) return null;
-  return { apiKey, to, from };
+interface EmailDeliveryOptions extends NotifyOptions {
+  to: string | string[];
+  from?: string;
+  context: string;
 }
 
-async function sendNotification(options: NotifyOptions, context: string): Promise<void> {
-  const config = getResendConfig();
-  if (!config) {
-    logger.debug(`Skipping ${context} notification because email config is missing`);
+function getResendApiKey(): string | null {
+  return process.env.RESEND_API_KEY ?? null;
+}
+
+function getDefaultFromAddress(): string {
+  return process.env.BOOKINGS_NOTIFY_FROM ?? 'alerts@stroman-properties.com';
+}
+
+function normalizeRecipients(to: string | string[]): string[] {
+  const raw = Array.isArray(to) ? to : [to];
+  return raw
+    .map((value) => value.trim())
+    .filter((value) => Boolean(value));
+}
+
+async function sendEmail(options: EmailDeliveryOptions): Promise<void> {
+  const apiKey = getResendApiKey();
+  if (!apiKey) {
+    logger.debug(`Skipping ${options.context} email because RESEND_API_KEY is not configured`);
     return;
   }
+
+  const recipients = normalizeRecipients(options.to);
+  if (!recipients.length) {
+    logger.debug(`Skipping ${options.context} email because no recipients were provided`);
+    return;
+  }
+
+  const payload = {
+    from: options.from?.trim() || getDefaultFromAddress(),
+    to: recipients,
+    subject: options.subject,
+    text: options.body,
+  };
+
   try {
     const response = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${config.apiKey}`,
+        Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        from: config.from,
-        to: config.to,
-        subject: options.subject,
-        text: options.body,
-      }),
+      body: JSON.stringify(payload),
     });
     if (!response.ok) {
       const text = await response.text().catch(() => '');
       throw new Error(`Resend request failed (${response.status}): ${text}`);
     }
   } catch (error) {
-    logger.error(`Failed to send ${context} notification`, error);
+    logger.error(`Failed to send ${options.context} email`, error);
   }
 }
 
+function getOwnerRecipient(): string | null {
+  return process.env.BOOKINGS_NOTIFY_TO ?? null;
+}
+
 export async function sendFailureNotification(options: NotifyOptions): Promise<void> {
-  await sendNotification(options, 'failure');
+  const to = getOwnerRecipient();
+  if (!to) {
+    logger.debug('Skipping failure notification because BOOKINGS_NOTIFY_TO is not set');
+    return;
+  }
+  await sendEmail({
+    to,
+    from: process.env.BOOKINGS_NOTIFY_FROM,
+    subject: options.subject,
+    body: options.body,
+    context: 'failure notification',
+  });
 }
 
 export async function sendOwnerNotification(options: NotifyOptions): Promise<void> {
-  await sendNotification(options, 'owner');
+  const to = getOwnerRecipient();
+  if (!to) {
+    logger.debug('Skipping owner notification because BOOKINGS_NOTIFY_TO is not set');
+    return;
+  }
+  await sendEmail({
+    to,
+    from: process.env.BOOKINGS_NOTIFY_FROM,
+    subject: options.subject,
+    body: options.body,
+    context: 'owner notification',
+  });
+}
+
+export async function sendGuestNotification(
+  recipient: string,
+  options: NotifyOptions,
+): Promise<void> {
+  await sendEmail({
+    to: recipient,
+    from: process.env.BOOKINGS_GUEST_FROM ?? process.env.BOOKINGS_NOTIFY_FROM,
+    subject: options.subject,
+    body: options.body,
+    context: 'guest notification',
+  });
 }
 


### PR DESCRIPTION
## Summary
- add admin-protected endpoints to verify, expire, or cancel booking holds
- share admin booking utilities for Supabase access and auditing
- extend notifications helper to support configurable guest emails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d48760c5d483288786b074ce5cbcf6