### PR TITLE
fix: lazily render emails on server

### DIFF
--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -2,8 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import type { Property } from '@/lib/properties';
-
-type PaymentMethod = 'zelle' | 'venmo' | 'paypal';
+import { PAYMENT_OPTIONS, type PaymentMethod } from '@/lib/paymentOptions';
 
 type HoldResponse = {
   invoice_number: number | string;
@@ -18,34 +17,6 @@ interface BookingSidebarProps {
   propertyTimezone: string;
   holdWindowHours: number;
 }
-
-interface PaymentOption {
-  id: PaymentMethod;
-  label: string;
-  recipient: string;
-  instructions: string;
-}
-
-const PAYMENT_OPTIONS: PaymentOption[] = [
-  {
-    id: 'zelle',
-    label: 'Zelle',
-    recipient: 'payments@stromanproperties.com',
-    instructions: 'Send via your banking app to Stroman Properties. Include the memo so we can match your transfer quickly.',
-  },
-  {
-    id: 'venmo',
-    label: 'Venmo',
-    recipient: '@StromanProperties',
-    instructions: 'Open Venmo and send to @StromanProperties. Use the memo exactly and add your stay dates in the notes.',
-  },
-  {
-    id: 'paypal',
-    label: 'PayPal',
-    recipient: 'paypal.me/stromanproperties',
-    instructions: 'Visit paypal.me/stromanproperties and submit the total as “Friends & Family” when possible to avoid fees.',
-  },
-];
 
 interface FormState {
   fullName: string;

--- a/emails/booking-confirmed.tsx
+++ b/emails/booking-confirmed.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import { renderEmail, type EmailContent } from '@/lib/email';
+import {
+  EmailLayout,
+  PolicyLinksList,
+  buttonStyle,
+  headingStyle,
+  subheadingStyle,
+  textStyle,
+  POLICY_LINKS,
+} from './layout';
+import {
+  formatDateTimeDisplay,
+  formatStayRange,
+  type StayDetails,
+} from '@/lib/stays';
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'separate',
+  borderSpacing: '0 8px',
+  margin: '0 0 24px',
+};
+
+const labelStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  fontWeight: 600,
+  width: '45%',
+};
+
+const valueStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  textAlign: 'right',
+  width: '55%',
+};
+
+const itineraryButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  backgroundColor: '#2563eb',
+};
+
+export interface BookingConfirmedEmailProps {
+  guestName: string | null;
+  invoiceNumber: string;
+  stay: StayDetails | null;
+  paidAt: string;
+  arrivalGuideUrl: string;
+}
+
+function BookingConfirmedEmail(props: BookingConfirmedEmailProps) {
+  const { guestName, invoiceNumber, stay, paidAt, arrivalGuideUrl } = props;
+  const greeting = guestName?.trim() ? `Hi ${guestName.trim()},` : 'Hello,';
+  const paidAtDisplay = formatDateTimeDisplay(paidAt);
+  const stayRange = stay ? formatStayRange(stay) : null;
+
+  const rows = [
+    { label: 'Invoice', value: invoiceNumber },
+    stay ? { label: 'Check-in', value: stay.checkInDisplay } : null,
+    stay ? { label: 'Check-out', value: stay.checkOutDisplay } : null,
+    stay ? { label: 'Nights', value: String(stay.nights) } : null,
+    { label: 'Payment verified', value: paidAtDisplay },
+  ].filter(Boolean) as { label: string; value: string }[];
+
+  return (
+    <EmailLayout title="[Ashburn VA Stay] Booking Confirmed">
+      <h1 style={headingStyle}>Your stay is confirmed!</h1>
+      <p style={textStyle}>{greeting}</p>
+      <p style={textStyle}>
+        We received your payment and locked in your stay at Ashburn VA Stay
+        {stayRange ? ` (${stayRange})` : ''}. We can&rsquo;t wait to host you.
+      </p>
+      <table style={tableStyle} role="presentation">
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td style={labelStyle}>{row.label}</td>
+              <td style={valueStyle}>{row.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <h2 style={subheadingStyle}>Next steps</h2>
+      <p style={textStyle}>
+        In the days leading up to your arrival we&rsquo;ll send detailed check-in instructions, Wi-Fi
+        credentials, and local recommendations. In the meantime you can review our welcome guide
+        anytime.
+      </p>
+      <p style={{ ...textStyle, textAlign: 'center' }}>
+        <a href={arrivalGuideUrl} style={itineraryButtonStyle}>
+          View welcome guide
+        </a>
+      </p>
+      <h2 style={subheadingStyle}>House rules &amp; policies</h2>
+      <PolicyLinksList />
+      <p style={textStyle}>
+        Warm regards,
+        <br />
+        Stroman Properties
+      </p>
+    </EmailLayout>
+  );
+}
+
+function createBookingConfirmedText(props: BookingConfirmedEmailProps): string {
+  const { guestName, invoiceNumber, stay, paidAt, arrivalGuideUrl } = props;
+  const lines: string[] = [];
+  lines.push(`Hi ${guestName?.trim() ? guestName.trim() : 'there'},`);
+  lines.push('');
+  lines.push('Great news — your booking is confirmed!');
+  lines.push(`Invoice: ${invoiceNumber}`);
+  if (stay) {
+    lines.push(`Check-in: ${stay.checkInDisplay}`);
+    lines.push(`Check-out: ${stay.checkOutDisplay}`);
+    lines.push(`Nights: ${stay.nights}`);
+  }
+  lines.push(`Payment verified: ${formatDateTimeDisplay(paidAt)}`);
+  lines.push('');
+  lines.push(`Welcome guide: ${arrivalGuideUrl}`);
+  lines.push('');
+  lines.push('Policies:');
+  POLICY_LINKS.forEach((link) => {
+    lines.push(`- ${link.label}: ${link.href}`);
+  });
+  lines.push('');
+  lines.push('Warm regards,');
+  lines.push('Stroman Properties');
+  return lines.join('\n');
+}
+
+export async function buildBookingConfirmedEmail(
+  props: BookingConfirmedEmailProps,
+): Promise<EmailContent> {
+  const subject = `[Ashburn VA Stay] Booking Confirmed - Invoice ${props.invoiceNumber}`;
+  const html = await renderEmail(<BookingConfirmedEmail {...props} />);
+  const text = createBookingConfirmedText(props);
+  return { subject, html, text };
+}

--- a/emails/booking-hold.tsx
+++ b/emails/booking-hold.tsx
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import type { PaymentOption } from '@/lib/paymentOptions';
+import { renderEmail, type EmailContent } from '@/lib/email';
+import {
+  EmailLayout,
+  PolicyLinksList,
+  buttonStyle,
+  emphasisStyle,
+  headingStyle,
+  subheadingStyle,
+  textStyle,
+  POLICY_LINKS,
+} from './layout';
+import {
+  formatDateTimeDisplay,
+  formatStayRange,
+  type StayDetails,
+} from '@/lib/stays';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const summaryTableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'separate',
+  borderSpacing: '0 8px',
+  margin: '0 0 24px',
+};
+
+const summaryLabelStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  fontWeight: 600,
+  width: '45%',
+};
+
+const summaryValueStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  textAlign: 'right',
+  width: '55%',
+};
+
+export interface BookingHoldEmailProps {
+  guestName: string | null;
+  invoiceNumber: string;
+  stay: StayDetails | null;
+  holdExpiresAt: string;
+  totalAmount: number;
+  paymentOption: PaymentOption | null;
+  proofUrl: string;
+}
+
+function formatCurrency(amount: number): string {
+  return currencyFormatter.format(Math.round(amount * 100) / 100);
+}
+
+function BookingHoldEmail(props: BookingHoldEmailProps) {
+  const {
+    guestName,
+    invoiceNumber,
+    stay,
+    holdExpiresAt,
+    totalAmount,
+    paymentOption,
+    proofUrl,
+  } = props;
+  const greeting = guestName?.trim() ? `Hi ${guestName.trim()},` : 'Hello,';
+  const stayRange = stay ? formatStayRange(stay) : null;
+  const holdExpiresDisplay = formatDateTimeDisplay(holdExpiresAt);
+  const totalDisplay = formatCurrency(totalAmount);
+
+  const rows = [
+    { label: 'Invoice', value: invoiceNumber },
+    stay ? { label: 'Check-in', value: stay.checkInDisplay } : null,
+    stay ? { label: 'Check-out', value: stay.checkOutDisplay } : null,
+    stay ? { label: 'Nights', value: String(stay.nights) } : null,
+    { label: 'Total due', value: totalDisplay },
+    { label: 'Hold expires', value: holdExpiresDisplay },
+  ].filter(Boolean) as { label: string; value: string }[];
+
+  return (
+    <EmailLayout title="[Ashburn VA Stay] Hold Created">
+      <h1 style={headingStyle}>Hold confirmed for Ashburn VA Stay</h1>
+      <p style={textStyle}>{greeting}</p>
+      <p style={textStyle}>
+        Thanks for choosing Ashburn VA Stay! We have placed a temporary hold on your
+        requested dates
+        {stayRange ? ` (${stayRange})` : ''} while we await your payment.
+      </p>
+      <table style={summaryTableStyle} role="presentation">
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td style={summaryLabelStyle}>{row.label}</td>
+              <td style={summaryValueStyle}>{row.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <h2 style={subheadingStyle}>How to complete your payment</h2>
+      {paymentOption ? (
+        <>
+          <p style={textStyle}>
+            Send <span style={emphasisStyle}>{totalDisplay}</span> via{' '}
+            <span style={emphasisStyle}>{paymentOption.label}</span> to{' '}
+            <span style={emphasisStyle}>{paymentOption.recipient}</span>.
+          </p>
+          <p style={textStyle}>{paymentOption.instructions}</p>
+        </>
+      ) : (
+        <p style={textStyle}>
+          Use the payment method you selected to remit <span style={emphasisStyle}>{totalDisplay}</span>
+          {' '}to Stroman Properties.
+        </p>
+      )}
+      <p style={textStyle}>
+        Once your transfer is sent, upload proof so we can verify and fully confirm your stay.
+      </p>
+      <p style={{ ...textStyle, textAlign: 'center' }}>
+        <a href={proofUrl} style={buttonStyle}>
+          Upload payment proof
+        </a>
+      </p>
+      <h2 style={subheadingStyle}>House rules &amp; policies</h2>
+      <PolicyLinksList />
+      <p style={textStyle}>
+        Warm regards,
+        <br />
+        Stroman Properties
+      </p>
+    </EmailLayout>
+  );
+}
+
+function createBookingHoldText(props: BookingHoldEmailProps): string {
+  const {
+    guestName,
+    invoiceNumber,
+    stay,
+    holdExpiresAt,
+    totalAmount,
+    paymentOption,
+    proofUrl,
+  } = props;
+  const lines: string[] = [];
+  lines.push(`Hi ${guestName?.trim() ? guestName.trim() : 'there'},`);
+  lines.push('');
+  if (stay) {
+    lines.push(
+      `We\'ve placed a temporary hold on Ashburn VA Stay from ${stay.checkInDisplay} to ${stay.checkOutDisplay}.`,
+    );
+  } else {
+    lines.push("We've placed a temporary hold on Ashburn VA Stay for your requested dates.");
+  }
+  lines.push(`Invoice: ${invoiceNumber}`);
+  if (stay) {
+    lines.push(`Nights: ${stay.nights}`);
+    lines.push(`Check-in: ${stay.checkInDisplay}`);
+    lines.push(`Check-out: ${stay.checkOutDisplay}`);
+  }
+  lines.push(`Total due: ${formatCurrency(totalAmount)}`);
+  lines.push(`Hold expires: ${formatDateTimeDisplay(holdExpiresAt)}`);
+  lines.push('');
+  if (paymentOption) {
+    lines.push(
+      `Send ${formatCurrency(totalAmount)} via ${paymentOption.label} to ${paymentOption.recipient}.`,
+    );
+    lines.push(paymentOption.instructions);
+  } else {
+    lines.push('Use the payment method you selected to submit your total.');
+  }
+  lines.push('');
+  lines.push(`Upload proof so we can verify your payment: ${proofUrl}`);
+  lines.push('');
+  lines.push('Policies:');
+  POLICY_LINKS.forEach((link) => {
+    lines.push(`- ${link.label}: ${link.href}`);
+  });
+  lines.push('');
+  lines.push('Warm regards,');
+  lines.push('Stroman Properties');
+  return lines.join('\n');
+}
+
+export async function buildBookingHoldEmail(
+  props: BookingHoldEmailProps,
+): Promise<EmailContent> {
+  const subject = `[Ashburn VA Stay] Hold Created - Invoice ${props.invoiceNumber}`;
+  const html = await renderEmail(<BookingHoldEmail {...props} />);
+  const text = createBookingHoldText(props);
+  return { subject, html, text };
+}

--- a/emails/hold-expired.tsx
+++ b/emails/hold-expired.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { renderEmail, type EmailContent } from '@/lib/email';
+import {
+  EmailLayout,
+  PolicyLinksList,
+  headingStyle,
+  subheadingStyle,
+  textStyle,
+  POLICY_LINKS,
+} from './layout';
+import {
+  formatDateTimeDisplay,
+  formatStayRange,
+  type StayDetails,
+} from '@/lib/stays';
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'separate',
+  borderSpacing: '0 8px',
+  margin: '0 0 24px',
+};
+
+const labelStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  fontWeight: 600,
+  width: '45%',
+};
+
+const valueStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  textAlign: 'right',
+  width: '55%',
+};
+
+export interface HoldExpiredEmailProps {
+  guestName: string | null;
+  invoiceNumber: string;
+  stay: StayDetails | null;
+  expiredAt: string;
+  holdExpiresAt: string | null;
+}
+
+function HoldExpiredEmail(props: HoldExpiredEmailProps) {
+  const { guestName, invoiceNumber, stay, expiredAt, holdExpiresAt } = props;
+  const greeting = guestName?.trim() ? `Hi ${guestName.trim()},` : 'Hello,';
+  const expiredDisplay = formatDateTimeDisplay(expiredAt);
+  const scheduledExpiry = holdExpiresAt ? formatDateTimeDisplay(holdExpiresAt) : null;
+  const stayRange = stay ? formatStayRange(stay) : null;
+
+  const rows = [
+    { label: 'Invoice', value: invoiceNumber },
+    stay ? { label: 'Requested stay', value: stayRange ?? `${stay.checkInDisplay} – ${stay.checkOutDisplay}` } : null,
+    scheduledExpiry ? { label: 'Original hold deadline', value: scheduledExpiry } : null,
+    { label: 'Expired at', value: expiredDisplay },
+  ].filter(Boolean) as { label: string; value: string }[];
+
+  return (
+    <EmailLayout title="[Ashburn VA Stay] Hold Expired">
+      <h1 style={headingStyle}>Hold expired</h1>
+      <p style={textStyle}>{greeting}</p>
+      <p style={textStyle}>
+        We didn&rsquo;t receive payment in time, so the temporary hold on Ashburn VA Stay has expired.
+        The dates you requested are now available for other guests.
+      </p>
+      <table style={tableStyle} role="presentation">
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td style={labelStyle}>{row.label}</td>
+              <td style={valueStyle}>{row.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <h2 style={subheadingStyle}>Need assistance?</h2>
+      <p style={textStyle}>
+        If you still want to stay with us, reply to this email and we&rsquo;ll help you set up a new hold
+        or explore alternative dates.
+      </p>
+      <h2 style={subheadingStyle}>House rules &amp; policies</h2>
+      <PolicyLinksList />
+      <p style={textStyle}>Regards,
+        <br />
+        Stroman Properties
+      </p>
+    </EmailLayout>
+  );
+}
+
+function createHoldExpiredText(props: HoldExpiredEmailProps): string {
+  const { guestName, invoiceNumber, stay, expiredAt, holdExpiresAt } = props;
+  const lines: string[] = [];
+  lines.push(`Hi ${guestName?.trim() ? guestName.trim() : 'there'},`);
+  lines.push('');
+  lines.push('Your booking hold has expired.');
+  lines.push(`Invoice: ${invoiceNumber}`);
+  if (stay) {
+    lines.push(`Requested stay: ${stay.checkInDisplay} to ${stay.checkOutDisplay}`);
+  }
+  if (holdExpiresAt) {
+    lines.push(`Original deadline: ${formatDateTimeDisplay(holdExpiresAt)}`);
+  }
+  lines.push(`Expired at: ${formatDateTimeDisplay(expiredAt)}`);
+  lines.push('');
+  lines.push('Reply if you\'d like us to reopen the conversation or secure new dates.');
+  lines.push('');
+  lines.push('Policies:');
+  POLICY_LINKS.forEach((link) => {
+    lines.push(`- ${link.label}: ${link.href}`);
+  });
+  lines.push('');
+  lines.push('Regards,');
+  lines.push('Stroman Properties');
+  return lines.join('\n');
+}
+
+export async function buildHoldExpiredEmail(
+  props: HoldExpiredEmailProps,
+): Promise<EmailContent> {
+  const subject = `[Ashburn VA Stay] Hold Expired - Invoice ${props.invoiceNumber}`;
+  const html = await renderEmail(<HoldExpiredEmail {...props} />);
+  const text = createHoldExpiredText(props);
+  return { subject, html, text };
+}

--- a/emails/layout.tsx
+++ b/emails/layout.tsx
@@ -1,0 +1,132 @@
+/* eslint-disable @next/next/no-head-element */
+import * as React from 'react';
+
+const containerStyle: React.CSSProperties = {
+  backgroundColor: '#f5f5f5',
+  padding: '32px 16px',
+  margin: 0,
+};
+
+const cardStyle: React.CSSProperties = {
+  maxWidth: '640px',
+  margin: '0 auto',
+  backgroundColor: '#ffffff',
+  borderRadius: '16px',
+  padding: '32px',
+  boxShadow: '0 12px 36px rgba(15, 23, 42, 0.08)',
+};
+
+const footerStyle: React.CSSProperties = {
+  maxWidth: '640px',
+  margin: '24px auto 0',
+  fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  fontSize: '13px',
+  lineHeight: '18px',
+  color: '#475569',
+  textAlign: 'center',
+};
+
+export const textStyle: React.CSSProperties = {
+  fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  fontSize: '16px',
+  lineHeight: '24px',
+  color: '#0f172a',
+  margin: '0 0 16px',
+};
+
+export const headingStyle: React.CSSProperties = {
+  fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  fontSize: '22px',
+  lineHeight: '30px',
+  color: '#0f172a',
+  fontWeight: 700,
+  margin: '0 0 16px',
+};
+
+export const subheadingStyle: React.CSSProperties = {
+  fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  fontSize: '18px',
+  lineHeight: '26px',
+  color: '#0f172a',
+  fontWeight: 600,
+  margin: '24px 0 12px',
+};
+
+export const listStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: '0 0 16px 20px',
+  padding: 0,
+};
+
+export const listItemStyle: React.CSSProperties = {
+  margin: '0 0 8px',
+};
+
+export const emphasisStyle: React.CSSProperties = {
+  fontWeight: 600,
+};
+
+export const buttonStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '14px 24px',
+  backgroundColor: '#0f172a',
+  color: '#ffffff',
+  textDecoration: 'none',
+  borderRadius: '999px',
+  fontFamily: '"Helvetica Neue", Arial, sans-serif',
+  fontSize: '16px',
+  fontWeight: 600,
+};
+
+const SITE_FALLBACK = 'https://stromanproperties.com';
+
+export const SITE_URL = process.env.BOOKINGS_SITE_URL ?? SITE_FALLBACK;
+
+export const POLICY_LINKS = [
+  { label: 'House Rules', href: `${SITE_URL}/house-rules` },
+  { label: 'Cancellation Policy', href: `${SITE_URL}/cancellation-policy` },
+];
+
+interface EmailLayoutProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function EmailLayout({ title, children }: EmailLayoutProps) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <title>{title}</title>
+        <meta name="color-scheme" content="light" />
+      </head>
+      <body style={containerStyle}>
+        <div style={cardStyle}>{children}</div>
+        <p style={footerStyle}>
+          Need assistance? Reply to this email or contact{' '}
+          <a href="mailto:bookings@stromanproperties.com" style={{ color: '#0f172a' }}>
+            bookings@stromanproperties.com
+          </a>
+          .
+        </p>
+      </body>
+    </html>
+  );
+}
+
+export function PolicyLinksList() {
+  return (
+    <ul style={listStyle}>
+      {POLICY_LINKS.map((link) => (
+        <li key={link.href} style={listItemStyle}>
+          <a
+            href={link.href}
+            style={{ color: '#2563eb', textDecoration: 'none', fontWeight: 600 }}
+          >
+            {link.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/emails/payment-proof-received.tsx
+++ b/emails/payment-proof-received.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { renderEmail, type EmailContent } from '@/lib/email';
+import {
+  EmailLayout,
+  PolicyLinksList,
+  headingStyle,
+  subheadingStyle,
+  textStyle,
+  POLICY_LINKS,
+} from './layout';
+import { formatDateTimeDisplay, formatStayRange, type StayDetails } from '@/lib/stays';
+import { getPaymentLabel } from '@/lib/paymentOptions';
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'separate',
+  borderSpacing: '0 6px',
+  margin: '0 0 24px',
+};
+
+const labelStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  fontWeight: 600,
+  width: '40%',
+};
+
+const valueStyle: React.CSSProperties = {
+  ...textStyle,
+  margin: 0,
+  textAlign: 'right',
+  width: '60%',
+  wordBreak: 'break-word',
+};
+
+export interface PaymentProofEmailProps {
+  invoiceNumber: string;
+  payerName: string;
+  processor: string;
+  reference?: string | null;
+  note?: string | null;
+  proofUrl: string;
+  submittedAt: string;
+  stay: StayDetails | null;
+  paymentMethod: string | null;
+}
+
+function PaymentProofReceivedEmail(props: PaymentProofEmailProps) {
+  const { invoiceNumber, payerName, processor, reference, note, proofUrl, submittedAt, stay, paymentMethod } = props;
+  const receivedDisplay = formatDateTimeDisplay(submittedAt);
+  const paymentLabel = getPaymentLabel(processor || paymentMethod || 'Payment');
+  const stayDescription = stay ? `${formatStayRange(stay)} (${stay.nights} nights)` : '—';
+
+  const rows = [
+    { label: 'Invoice', value: invoiceNumber },
+    { label: 'Payer', value: payerName },
+    { label: 'Payment method', value: paymentLabel },
+    { label: 'Submitted', value: receivedDisplay },
+    { label: 'Stay', value: stayDescription },
+    reference ? { label: 'Reference', value: reference } : null,
+  ].filter(Boolean) as { label: string; value: string }[];
+
+  return (
+    <EmailLayout title="[Ashburn VA Stay] Payment Proof Received">
+      <h1 style={headingStyle}>Payment proof received</h1>
+      <p style={textStyle}>
+        A guest submitted proof of payment for Ashburn VA Stay. Please review the details below and
+        verify the booking when ready.
+      </p>
+      <table style={tableStyle} role="presentation">
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.label}>
+              <td style={labelStyle}>{row.label}</td>
+              <td style={valueStyle}>{row.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {note ? <p style={textStyle}>Guest note: {note}</p> : null}
+      <p style={textStyle}>
+        View the uploaded proof:
+        {' '}
+        <a href={proofUrl} style={{ color: '#2563eb', textDecoration: 'none', fontWeight: 600 }}>
+          {proofUrl}
+        </a>
+      </p>
+      <h2 style={subheadingStyle}>Next steps</h2>
+      <p style={textStyle}>
+        Confirm the payment in the admin dashboard and notify the guest once verified. If anything
+        looks incorrect, reach out to the guest before approving.
+      </p>
+      <h2 style={subheadingStyle}>Policies</h2>
+      <PolicyLinksList />
+      <p style={textStyle}>— Stroman Properties</p>
+    </EmailLayout>
+  );
+}
+
+function createPaymentProofText(props: PaymentProofEmailProps): string {
+  const { invoiceNumber, payerName, processor, reference, note, proofUrl, submittedAt, stay, paymentMethod } = props;
+  const lines: string[] = [];
+  const paymentLabel = getPaymentLabel(processor || paymentMethod || 'Payment');
+  lines.push('A guest submitted payment proof.');
+  lines.push(`Invoice: ${invoiceNumber}`);
+  lines.push(`Payer: ${payerName}`);
+  lines.push(`Method: ${paymentLabel}`);
+  lines.push(`Submitted: ${formatDateTimeDisplay(submittedAt)}`);
+  if (stay) {
+    lines.push(`Stay: ${stay.checkInDisplay} to ${stay.checkOutDisplay} (${stay.nights} nights)`);
+  }
+  if (reference) {
+    lines.push(`Reference: ${reference}`);
+  }
+  if (note) {
+    lines.push(`Note: ${note}`);
+  }
+  lines.push(`Proof URL: ${proofUrl}`);
+  lines.push('');
+  lines.push('Policies:');
+  POLICY_LINKS.forEach((link) => {
+    lines.push(`- ${link.label}: ${link.href}`);
+  });
+  return lines.join('\n');
+}
+
+export async function buildPaymentProofReceivedEmail(
+  props: PaymentProofEmailProps,
+): Promise<EmailContent> {
+  const subject = `[Ashburn VA Stay] Payment Proof Received - Invoice ${props.invoiceNumber}`;
+  const html = await renderEmail(<PaymentProofReceivedEmail {...props} />);
+  const text = createPaymentProofText(props);
+  return { subject, html, text };
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,32 @@
+import 'server-only';
+import type { ReactElement } from 'react';
+
+export interface EmailContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+let cachedRenderer: typeof import('react-dom/server').renderToStaticMarkup | null = null;
+
+async function getRenderer(): Promise<
+  typeof import('react-dom/server').renderToStaticMarkup
+> {
+  if (cachedRenderer) {
+    return cachedRenderer;
+  }
+
+  const reactDomServer = await import('react-dom/server');
+  if (typeof reactDomServer.renderToStaticMarkup !== 'function') {
+    throw new Error('react-dom/server does not expose renderToStaticMarkup');
+  }
+
+  cachedRenderer = reactDomServer.renderToStaticMarkup;
+  return cachedRenderer;
+}
+
+export async function renderEmail(element: ReactElement): Promise<string> {
+  const renderToStaticMarkup = await getRenderer();
+  const markup = renderToStaticMarkup(element);
+  return `<!DOCTYPE html>${markup}`;
+}

--- a/lib/paymentOptions.ts
+++ b/lib/paymentOptions.ts
@@ -1,0 +1,48 @@
+export type PaymentMethod = 'zelle' | 'venmo' | 'paypal';
+
+export interface PaymentOption {
+  id: PaymentMethod;
+  label: string;
+  recipient: string;
+  instructions: string;
+}
+
+export const PAYMENT_OPTIONS: PaymentOption[] = [
+  {
+    id: 'zelle',
+    label: 'Zelle',
+    recipient: 'payments@stromanproperties.com',
+    instructions:
+      'Send via your banking app to Stroman Properties. Include the memo so we can match your transfer quickly.',
+  },
+  {
+    id: 'venmo',
+    label: 'Venmo',
+    recipient: '@StromanProperties',
+    instructions:
+      'Open Venmo and send to @StromanProperties. Use the memo exactly and add your stay dates in the notes.',
+  },
+  {
+    id: 'paypal',
+    label: 'PayPal',
+    recipient: 'paypal.me/stromanproperties',
+    instructions:
+      'Visit paypal.me/stromanproperties and submit the total as “Friends & Family” when possible to avoid fees.',
+  },
+];
+
+export function getPaymentOption(method: string | null | undefined): PaymentOption | null {
+  if (!method) {
+    return null;
+  }
+  const normalized = method.trim().toLowerCase();
+  return PAYMENT_OPTIONS.find((option) => option.id === normalized) ?? null;
+}
+
+export function getPaymentLabel(method: string | null | undefined): string {
+  const option = getPaymentOption(method);
+  if (option) {
+    return option.label;
+  }
+  return method ? method.charAt(0).toUpperCase() + method.slice(1) : 'Payment';
+}

--- a/lib/stays.ts
+++ b/lib/stays.ts
@@ -1,0 +1,140 @@
+const DEFAULT_TIME_ZONE = process.env.BOOKINGS_TIME_ZONE ?? 'America/New_York';
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeZone: DEFAULT_TIME_ZONE,
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+  timeZone: DEFAULT_TIME_ZONE,
+});
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function parseDateOnly(value: string): Date {
+  const parts = value.split('-');
+  if (parts.length === 3) {
+    const [year, month, day] = parts.map((part) => Number(part));
+    if ([year, month, day].every((part) => Number.isFinite(part))) {
+      return new Date(Date.UTC(year, month - 1, day, 12));
+    }
+  }
+  return new Date(value);
+}
+
+function parseInputDate(value: string): Date {
+  if (!value) {
+    return new Date(NaN);
+  }
+  return value.includes('T') ? new Date(value) : parseDateOnly(value);
+}
+
+function toUtcDayValue(value: string): number {
+  const date = parseInputDate(value);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export interface StayDetails {
+  checkIn: string;
+  checkOut: string;
+  checkInDisplay: string;
+  checkOutDisplay: string;
+  nights: number;
+}
+
+export function formatDateDisplay(value: string): string {
+  const parsed = parseInputDate(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return dateFormatter.format(parsed);
+}
+
+export function formatDateTimeDisplay(value: string): string {
+  const parsed = parseInputDate(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return dateTimeFormatter.format(parsed);
+}
+
+export function calculateNights(checkIn: string, checkOut: string): number {
+  const start = toUtcDayValue(checkIn);
+  const end = toUtcDayValue(checkOut);
+  const diff = end - start;
+  if (!Number.isFinite(diff) || diff <= 0) {
+    return 0;
+  }
+  return Math.round(diff / MS_PER_DAY);
+}
+
+export function createStayDetails(checkIn: string, checkOut: string): StayDetails {
+  return {
+    checkIn,
+    checkOut,
+    checkInDisplay: formatDateDisplay(checkIn),
+    checkOutDisplay: formatDateDisplay(checkOut),
+    nights: calculateNights(checkIn, checkOut),
+  };
+}
+
+interface CalendarBlockLike {
+  start_date: string;
+  end_date: string;
+}
+
+export function createStayDetailsFromBlocks(
+  blocks: CalendarBlockLike[],
+): StayDetails | null {
+  if (!blocks.length) {
+    return null;
+  }
+  const start = blocks.reduce(
+    (min, block) => (block.start_date < min ? block.start_date : min),
+    blocks[0].start_date,
+  );
+  const end = blocks.reduce(
+    (max, block) => (block.end_date > max ? block.end_date : max),
+    blocks[0].end_date,
+  );
+  return createStayDetails(start, end);
+}
+
+export function formatStayRange(details: StayDetails): string {
+  const checkInDate = parseInputDate(details.checkIn);
+  const checkOutDate = parseInputDate(details.checkOut);
+  if (Number.isNaN(checkInDate.getTime()) || Number.isNaN(checkOutDate.getTime())) {
+    return `${details.checkInDisplay} – ${details.checkOutDisplay}`;
+  }
+  const sameYear = checkInDate.getUTCFullYear() === checkOutDate.getUTCFullYear();
+  const sameMonth =
+    sameYear && checkInDate.getUTCMonth() === checkOutDate.getUTCMonth();
+  const monthDayFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: DEFAULT_TIME_ZONE,
+  });
+  const endFormatter = sameYear
+    ? sameMonth
+      ? new Intl.DateTimeFormat('en-US', {
+          day: 'numeric',
+          timeZone: DEFAULT_TIME_ZONE,
+        })
+      : monthDayFormatter
+    : new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: DEFAULT_TIME_ZONE,
+      });
+
+  const startLabel = monthDayFormatter.format(checkInDate);
+  const endLabel = endFormatter.format(checkOutDate);
+  const yearLabel = sameYear
+    ? checkInDate.getUTCFullYear().toString()
+    : `${checkInDate.getUTCFullYear()} – ${checkOutDate.getUTCFullYear()}`;
+
+  return `${startLabel} – ${endLabel}, ${yearLabel}`;
+}


### PR DESCRIPTION
## Summary
- lazily import the server renderer when composing email HTML to satisfy Turbopack's restrictions
- make booking email factory helpers asynchronous and await them from API routes before dispatching notifications

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d496f6cb588328b0d077b59df93bad