### PR TITLE
Add owner dashboard for managing booking holds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1158,3 +1158,140 @@ button:hover,
 }
 
 
+button:disabled,
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.owner-dashboard {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.owner-dashboard h1 {
+  margin-bottom: 0.25rem;
+}
+
+.owner-dashboard__subtitle {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  color: var(--color-text-secondary);
+}
+
+.owner-dashboard__error {
+  padding: 1rem;
+  border-radius: 8px;
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.owner-dashboard__empty {
+  padding: 1rem;
+  border-radius: 8px;
+  background: #eff6ff;
+  color: var(--color-primary);
+}
+
+.owner-bookings__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.owner-booking {
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(3, 59, 136, 0.08);
+}
+
+.owner-booking__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.owner-booking__status {
+  margin: 0.5rem 0 0;
+  color: var(--color-text-secondary);
+}
+
+.owner-booking__badge {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.owner-booking__badge.expired {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.owner-booking__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.owner-booking__grid section {
+  background: rgba(224, 242, 254, 0.2);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.owner-booking__grid h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.owner-booking__proof-link {
+  font-weight: 600;
+}
+
+.owner-booking__no-proof {
+  color: var(--color-text-secondary);
+}
+
+.owner-booking__messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.owner-booking__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.owner-booking__success {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: #dcfce7;
+  color: #166534;
+}
+
+.owner-booking__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+@media (max-width: 600px) {
+  .owner-dashboard {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .owner-booking__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/owner/bookings/page.tsx
+++ b/app/owner/bookings/page.tsx
@@ -1,0 +1,214 @@
+import { cookies, headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import OwnerBookingRow, { type OwnerBookingDetails, type OwnerBookingGuest, type OwnerBookingPayment } from '@/components/OwnerBookingRow';
+import { createStayDetails } from '@/lib/stays';
+import { supabaseJson } from '@/lib/supabase/rest';
+
+interface PendingBookingRecord {
+  id: string;
+  invoice_number: string;
+  status: string;
+  hold_expires_at: string | null;
+  guest_id: string | null;
+  check_in: string | null;
+  check_out: string | null;
+  rate_subtotal: number | null;
+  cleaning_fee: number | null;
+  taxes: number | null;
+  total_amount: number | null;
+  payment_method: string | null;
+}
+
+interface GuestRecord {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+interface PaymentRecord {
+  id: string;
+  booking_id: string;
+  status: string | null;
+  processor: string | null;
+  payer_name: string | null;
+  reference: string | null;
+  note: string | null;
+  proof_file_url: string | null;
+  received_at: string | null;
+  verified_at: string | null;
+  amount: number | null;
+}
+
+const ADMIN_COOKIE_NAME = 'admin_secret';
+
+function getAdminSecret(): string | null {
+  const secret = process.env.ADMIN_API_SECRET;
+  if (!secret) {
+    return null;
+  }
+  return secret.trim();
+}
+
+function isAuthorized(): boolean {
+  const secret = getAdminSecret();
+  if (!secret) {
+    return false;
+  }
+  const headerSecret = headers().get('x-admin-secret')?.trim();
+  if (headerSecret && headerSecret === secret) {
+    return true;
+  }
+  const cookieStore = cookies();
+  const cookieSecret = cookieStore.get(ADMIN_COOKIE_NAME)?.value?.trim();
+  return Boolean(cookieSecret && cookieSecret === secret);
+}
+
+function isHoldExpired(holdExpiresAt: string | null): boolean {
+  if (!holdExpiresAt) {
+    return false;
+  }
+  const expires = new Date(holdExpiresAt);
+  if (Number.isNaN(expires.getTime())) {
+    return true;
+  }
+  return expires.getTime() <= Date.now();
+}
+
+function encodeList(values: string[]): string {
+  return values.map((value) => encodeURIComponent(value)).join(',');
+}
+
+async function fetchPendingBookings(): Promise<PendingBookingRecord[]> {
+  return (
+    await supabaseJson<PendingBookingRecord[]>(
+      '/bookings?status=eq.pending_hold&select=id,invoice_number,status,hold_expires_at,guest_id,check_in,check_out,rate_subtotal,cleaning_fee,taxes,total_amount,payment_method&order=hold_expires_at.asc',
+    )
+  ) ?? [];
+}
+
+async function fetchGuests(guestIds: string[]): Promise<Map<string, OwnerBookingGuest>> {
+  if (!guestIds.length) {
+    return new Map();
+  }
+  const records =
+    (await supabaseJson<GuestRecord[]>(
+      `/guests?id=in.(${encodeList(guestIds)})&select=id,full_name,email,phone`,
+    )) ?? [];
+  return new Map(
+    records.map((guest) => [
+      guest.id,
+      {
+        id: guest.id,
+        fullName: guest.full_name,
+        email: guest.email,
+        phone: guest.phone,
+      },
+    ]),
+  );
+}
+
+async function fetchPayments(bookingIds: string[]): Promise<Map<string, OwnerBookingPayment>> {
+  if (!bookingIds.length) {
+    return new Map();
+  }
+  const records =
+    (await supabaseJson<PaymentRecord[]>(
+      `/payments?booking_id=in.(${encodeList(bookingIds)})&select=id,booking_id,status,processor,payer_name,reference,note,proof_file_url,received_at,verified_at,amount&order=created_at.desc`,
+    )) ?? [];
+
+  const map = new Map<string, OwnerBookingPayment>();
+  for (const record of records) {
+    if (map.has(record.booking_id)) {
+      continue;
+    }
+    map.set(record.booking_id, {
+      id: record.id,
+      status: record.status,
+      processor: record.processor,
+      payerName: record.payer_name,
+      reference: record.reference,
+      note: record.note,
+      proofFileUrl: record.proof_file_url,
+      receivedAt: record.received_at,
+      verifiedAt: record.verified_at,
+      amount: record.amount,
+    });
+  }
+  return map;
+}
+
+async function loadOwnerBookings(): Promise<OwnerBookingDetails[]> {
+  const bookings = await fetchPendingBookings();
+  if (!bookings.length) {
+    return [];
+  }
+  const guestIds = Array.from(new Set(bookings.map((booking) => booking.guest_id).filter(Boolean))) as string[];
+  const bookingIds = bookings.map((booking) => booking.id);
+
+  const [guestMap, paymentMap] = await Promise.all([
+    fetchGuests(guestIds),
+    fetchPayments(bookingIds),
+  ]);
+
+  return bookings.map<OwnerBookingDetails>((booking) => {
+    const stayDetails =
+      booking.check_in && booking.check_out
+        ? createStayDetails(booking.check_in, booking.check_out)
+        : null;
+    return {
+      id: booking.id,
+      invoiceNumber: booking.invoice_number,
+      status: booking.status,
+      holdExpiresAt: booking.hold_expires_at,
+      isHoldExpired: isHoldExpired(booking.hold_expires_at),
+      checkIn: booking.check_in,
+      checkOut: booking.check_out,
+      nights: stayDetails?.nights ?? null,
+      rateSubtotal: booking.rate_subtotal,
+      cleaningFee: booking.cleaning_fee,
+      taxes: booking.taxes,
+      totalAmount: booking.total_amount,
+      paymentMethod: booking.payment_method,
+      guest: booking.guest_id ? guestMap.get(booking.guest_id) ?? null : null,
+      payment: paymentMap.get(booking.id) ?? null,
+    };
+  });
+}
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export default async function OwnerBookingsPage() {
+  if (!isAuthorized()) {
+    notFound();
+  }
+
+  let bookings: OwnerBookingDetails[] = [];
+  let error: string | null = null;
+  try {
+    bookings = await loadOwnerBookings();
+  } catch (err) {
+    error = err instanceof Error ? err.message : 'Failed to load pending bookings.';
+  }
+
+  return (
+    <div className="owner-dashboard">
+      <h1>Pending Booking Holds</h1>
+      <p className="owner-dashboard__subtitle">
+        Review payment proof submissions and confirm or expire holds.
+      </p>
+      {error ? (
+        <p className="owner-dashboard__error">{error}</p>
+      ) : bookings.length === 0 ? (
+        <p className="owner-dashboard__empty">No pending holds awaiting review.</p>
+      ) : (
+        <div className="owner-bookings__list">
+          {bookings.map((booking) => (
+            <OwnerBookingRow key={booking.id} booking={booking} adminCookieName={ADMIN_COOKIE_NAME} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/OwnerBookingRow.tsx
+++ b/components/OwnerBookingRow.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useState } from 'react';
+import { formatDateDisplay, formatDateTimeDisplay } from '@/lib/stays';
+
+const CURRENCY_FORMAT = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+function formatCurrency(value: number | null | undefined): string {
+  if (typeof value !== 'number') {
+    return '—';
+  }
+  return CURRENCY_FORMAT.format(Math.round(value * 100) / 100);
+}
+
+function getCookieValue(name: string): string | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const pattern = new RegExp(`(?:^|; )${name.replace(/[.$?*|{}()\[\]\\/\+^]/g, '\\$&')}=([^;]*)`);
+  const match = document.cookie.match(pattern);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+async function postAdminAction(
+  path: string,
+  body: Record<string, unknown>,
+  adminSecret: string,
+): Promise<Response> {
+  return fetch(path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-admin-secret': adminSecret,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export interface OwnerBookingPayment {
+  id: string;
+  status: string | null;
+  processor: string | null;
+  payerName: string | null;
+  reference: string | null;
+  note: string | null;
+  proofFileUrl: string | null;
+  receivedAt: string | null;
+  verifiedAt: string | null;
+  amount: number | null;
+}
+
+export interface OwnerBookingGuest {
+  id: string;
+  fullName: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+export interface OwnerBookingDetails {
+  id: string;
+  invoiceNumber: string;
+  status: string;
+  holdExpiresAt: string | null;
+  isHoldExpired: boolean;
+  checkIn: string | null;
+  checkOut: string | null;
+  nights: number | null;
+  rateSubtotal: number | null;
+  cleaningFee: number | null;
+  taxes: number | null;
+  totalAmount: number | null;
+  paymentMethod: string | null;
+  guest: OwnerBookingGuest | null;
+  payment: OwnerBookingPayment | null;
+}
+
+interface OwnerBookingRowProps {
+  booking: OwnerBookingDetails;
+  adminCookieName: string;
+}
+
+export default function OwnerBookingRow({ booking, adminCookieName }: OwnerBookingRowProps) {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isExpiring, setIsExpiring] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const holdExpiresDisplay = booking.holdExpiresAt
+    ? formatDateTimeDisplay(booking.holdExpiresAt)
+    : '—';
+  const checkInDisplay = booking.checkIn ? formatDateDisplay(booking.checkIn) : '—';
+  const checkOutDisplay = booking.checkOut ? formatDateDisplay(booking.checkOut) : '—';
+
+  const handleConfirm = async () => {
+    setError(null);
+    setMessage(null);
+
+    const adminSecret = getCookieValue(adminCookieName);
+    if (!adminSecret) {
+      setError('Missing admin secret cookie. Set the admin cookie to manage holds.');
+      return;
+    }
+
+    setIsConfirming(true);
+    try {
+      const response = await postAdminAction(
+        '/api/admin/bookings/verify',
+        { invoice_number: booking.invoiceNumber },
+        adminSecret,
+      );
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const errorMessage = payload?.error ?? `Unable to confirm hold (status ${response.status})`;
+        throw new Error(errorMessage);
+      }
+      setMessage('Hold confirmed successfully. Refreshing…');
+      setTimeout(() => {
+        window.location.reload();
+      }, 1200);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to confirm booking hold.');
+    } finally {
+      setIsConfirming(false);
+    }
+  };
+
+  const handleExpire = async () => {
+    setError(null);
+    setMessage(null);
+
+    const adminSecret = getCookieValue(adminCookieName);
+    if (!adminSecret) {
+      setError('Missing admin secret cookie. Set the admin cookie to manage holds.');
+      return;
+    }
+
+    setIsExpiring(true);
+    try {
+      const response = await postAdminAction(
+        '/api/admin/bookings/expire',
+        { invoice_number: booking.invoiceNumber, force: !booking.isHoldExpired },
+        adminSecret,
+      );
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const errorMessage = payload?.error ?? `Unable to expire hold (status ${response.status})`;
+        throw new Error(errorMessage);
+      }
+      setMessage('Hold expired. Refreshing…');
+      setTimeout(() => {
+        window.location.reload();
+      }, 1200);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to expire booking hold.');
+    } finally {
+      setIsExpiring(false);
+    }
+  };
+
+  const payment = booking.payment;
+  const disableConfirm = isConfirming || Boolean(payment && payment.status === 'verified');
+  const disableExpire = isExpiring;
+  const proofLink = payment?.proofFileUrl ?? null;
+  const paymentReceivedDisplay = payment?.receivedAt
+    ? formatDateTimeDisplay(payment.receivedAt)
+    : null;
+
+  return (
+    <article className="owner-booking card">
+      <header className="owner-booking__header">
+        <div>
+          <h2>Invoice {booking.invoiceNumber}</h2>
+          <p className="owner-booking__status">
+            Status: <span>{booking.status}</span>
+          </p>
+        </div>
+        <div className={`owner-booking__badge ${booking.isHoldExpired ? 'expired' : ''}`}>
+          Hold expires: {holdExpiresDisplay}
+        </div>
+      </header>
+
+      <div className="owner-booking__grid">
+        <section>
+          <h3>Guest</h3>
+          <p><strong>Name:</strong> {booking.guest?.fullName ?? '—'}</p>
+          <p><strong>Email:</strong> {booking.guest?.email ?? '—'}</p>
+          <p><strong>Phone:</strong> {booking.guest?.phone ?? '—'}</p>
+        </section>
+
+        <section>
+          <h3>Stay</h3>
+          <p><strong>Check-in:</strong> {checkInDisplay}</p>
+          <p><strong>Check-out:</strong> {checkOutDisplay}</p>
+          <p><strong>Nights:</strong> {booking.nights ?? '—'}</p>
+          <p><strong>Payment method:</strong> {booking.paymentMethod ?? '—'}</p>
+        </section>
+
+        <section>
+          <h3>Totals</h3>
+          <p><strong>Rate subtotal:</strong> {formatCurrency(booking.rateSubtotal)}</p>
+          <p><strong>Cleaning fee:</strong> {formatCurrency(booking.cleaningFee)}</p>
+          <p><strong>Taxes:</strong> {formatCurrency(booking.taxes)}</p>
+          <p><strong>Total due:</strong> {formatCurrency(booking.totalAmount)}</p>
+        </section>
+
+        <section>
+          <h3>Payment proof</h3>
+          <p><strong>Status:</strong> {payment?.status ?? '—'}</p>
+          <p><strong>Payer:</strong> {payment?.payerName ?? '—'}</p>
+          <p><strong>Processor:</strong> {payment?.processor ?? '—'}</p>
+          <p><strong>Reference:</strong> {payment?.reference ?? '—'}</p>
+          <p><strong>Received at:</strong> {paymentReceivedDisplay ?? '—'}</p>
+          <p><strong>Amount:</strong> {formatCurrency(payment?.amount ?? booking.totalAmount)}</p>
+          {proofLink ? (
+            <p>
+              <a href={proofLink} target="_blank" rel="noreferrer" className="owner-booking__proof-link">
+                View proof
+              </a>
+            </p>
+          ) : (
+            <p className="owner-booking__no-proof">No proof uploaded yet.</p>
+          )}
+        </section>
+      </div>
+
+      {(error || message) && (
+        <div className="owner-booking__messages">
+          {error ? <p className="owner-booking__error">{error}</p> : null}
+          {message ? <p className="owner-booking__success">{message}</p> : null}
+        </div>
+      )}
+
+      <footer className="owner-booking__actions">
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={disableConfirm || isExpiring || !proofLink}
+        >
+          {isConfirming ? 'Confirming…' : payment?.status === 'verified' ? 'Confirmed' : 'Confirm payment'}
+        </button>
+        <button type="button" onClick={handleExpire} disabled={disableExpire || isConfirming}>
+          {isExpiring ? 'Expiring…' : booking.isHoldExpired ? 'Expire hold' : 'Force expire'}
+        </button>
+      </footer>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- add a server-rendered owner bookings dashboard that fetches pending holds and applies an admin cookie/header gate
- create an OwnerBookingRow client component that surfaces guest, stay, totals, proof links, and verify/expire actions
- style the dashboard, cards, and disabled buttons to match the site aesthetics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a8602e2083289e21c61e5ea37206