### PR TITLE
Update payment options to highlight Zelle and Venmo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -358,20 +358,65 @@ p, label {
   margin: 0;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .payment-methods legend {
   font-weight: 600;
   color: var(--color-primary);
 }
 
-.payment-option {
+.payment-options {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.payment-option {
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(3, 59, 136, 0.25);
+  border-radius: 999px;
+  background: #fff;
   font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.payment-option:focus-within,
+.payment-option:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(3, 59, 136, 0.15);
 }
 
 .payment-option input {
   accent-color: var(--color-primary);
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.payment-option-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0;
+}
+
+.payment-option-image {
+  height: auto;
+  width: 96px;
 }
 
 .form-warning,

--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { useMemo, useState } from 'react';
 import type { Property } from '@/lib/properties';
 import { PAYMENT_OPTIONS, type PaymentMethod } from '@/lib/paymentOptions';
@@ -267,18 +268,29 @@ export default function BookingSidebar({
 
         <fieldset className="payment-methods" disabled={Boolean(holdDetails)}>
           <legend>Preferred payment</legend>
-          {PAYMENT_OPTIONS.map((option) => (
-            <label key={option.id} className="payment-option">
-              <input
-                type="radio"
-                name="payment-method"
-                value={option.id}
-                checked={form.paymentMethod === option.id}
-                onChange={() => setForm({ ...form, paymentMethod: option.id })}
-              />
-              <span>{option.label}</span>
-            </label>
-          ))}
+          <div className="payment-options">
+            {PAYMENT_OPTIONS.map((option) => (
+              <label key={option.id} className="payment-option">
+                <input
+                  type="radio"
+                  name="payment-method"
+                  value={option.id}
+                  checked={form.paymentMethod === option.id}
+                  onChange={() => setForm({ ...form, paymentMethod: option.id })}
+                />
+                <span className="payment-option-logo" aria-hidden="true">
+                  <Image
+                    src={option.logo.src}
+                    alt=""
+                    width={96}
+                    height={40}
+                    className="payment-option-image"
+                  />
+                </span>
+                <span className="sr-only">{option.label}</span>
+              </label>
+            ))}
+          </div>
         </fieldset>
 
         {hasBlockedOverlap ? (

--- a/lib/paymentOptions.ts
+++ b/lib/paymentOptions.ts
@@ -1,10 +1,14 @@
-export type PaymentMethod = 'zelle' | 'venmo' | 'paypal';
+export type PaymentMethod = 'zelle' | 'venmo';
 
 export interface PaymentOption {
   id: PaymentMethod;
   label: string;
   recipient: string;
   instructions: string;
+  logo: {
+    src: string;
+    alt: string;
+  };
 }
 
 export const PAYMENT_OPTIONS: PaymentOption[] = [
@@ -14,6 +18,10 @@ export const PAYMENT_OPTIONS: PaymentOption[] = [
     recipient: 'payments@stromanproperties.com',
     instructions:
       'Send via your banking app to Stroman Properties. Include the memo so we can match your transfer quickly.',
+    logo: {
+      src: '/images/payment-zelle.svg',
+      alt: 'Zelle',
+    },
   },
   {
     id: 'venmo',
@@ -21,13 +29,10 @@ export const PAYMENT_OPTIONS: PaymentOption[] = [
     recipient: '@StromanProperties',
     instructions:
       'Open Venmo and send to @StromanProperties. Use the memo exactly and add your stay dates in the notes.',
-  },
-  {
-    id: 'paypal',
-    label: 'PayPal',
-    recipient: 'paypal.me/stromanproperties',
-    instructions:
-      'Visit paypal.me/stromanproperties and submit the total as “Friends & Family” when possible to avoid fees.',
+    logo: {
+      src: '/images/payment-venmo.svg',
+      alt: 'Venmo',
+    },
   },
 ];
 

--- a/public/images/payment-venmo.svg
+++ b/public/images/payment-venmo.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="48" viewBox="0 0 120 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="48" rx="12" fill="#3D95CE"/>
+  <path d="M47 12H59L52.5 36H41L35 12H47L49.4 23L55 12H65L55.8 36H43.6L37.7 12H47Z" fill="white"/>
+</svg>

--- a/public/images/payment-zelle.svg
+++ b/public/images/payment-zelle.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="48" viewBox="0 0 120 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="48" rx="12" fill="#6C2DC7"/>
+  <path d="M38 12H86V19L57 33H86V36H38V29L67 15H38V12Z" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary
- remove the unused PayPal payment option and add logo metadata for the remaining methods
- render the booking form payment choices with app logos arranged horizontally
- add branded logo assets and styling updates for the payment method selector

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d52f7b71388328b5de595e3afb20e6