### PR TITLE
Add payment instructions component with env-configured details

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -459,8 +459,44 @@ p, label {
   color: var(--color-text-secondary);
 }
 
+.hold-next-steps .hold-countdown {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.hold-next-steps .hold-countdown.expired {
+  color: #8a1f1f;
+}
+
 .hold-next-steps strong {
   color: var(--color-primary);
+}
+
+.hold-next-steps .payment-instructions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hold-next-steps .payment-contact {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.hold-next-steps .payment-contact li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-top: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.hold-next-steps .payment-contact span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
 }
 
 .hold-next-steps .payment-memo {
@@ -468,6 +504,10 @@ p, label {
   background: rgba(59, 130, 246, 0.1);
   padding: 0.5rem 0.75rem;
   border-radius: 6px;
+}
+
+.hold-next-steps .method-note {
+  font-size: 0.85rem;
 }
 
 .hold-next-steps .proof-note,

--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useMemo, useState } from 'react';
+import PaymentInstructions from './PaymentInstructions';
 import type { Property } from '@/lib/properties';
 import { PAYMENT_OPTIONS, type PaymentMethod } from '@/lib/paymentOptions';
 
@@ -74,18 +75,6 @@ function formatMemo(
     day: '2-digit',
   }).format(stayEnd);
   return `Invoice ${invoiceNumber} / ${lastName || 'Guest'} / ${start}–${end}`;
-}
-
-function formatDateTimeInZone(value: string, timeZone: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return new Intl.DateTimeFormat('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-    timeZone,
-  }).format(date);
 }
 
 export default function BookingSidebar({
@@ -313,20 +302,14 @@ export default function BookingSidebar({
       {holdDetails && selectedPayment ? (
         <div className="hold-next-steps card">
           <h3>Next steps</h3>
-          <p>
-            Invoice <strong>{holdDetails.invoice_number}</strong> is reserved until{' '}
-            <strong>{formatDateTimeInZone(holdDetails.hold_expires_at, propertyTimezone)}</strong>.
-          </p>
-          <p>
-            Send the total via <strong>{selectedPayment.label}</strong> to{' '}
-            <strong>{selectedPayment.recipient}</strong>.
-          </p>
-          <p>{selectedPayment.instructions}</p>
-          {memoText ? (
-            <p className="payment-memo">
-              Memo: <strong>{memoText}</strong>
-            </p>
-          ) : null}
+          <PaymentInstructions
+            method={selectedPayment.id}
+            methodLabel={selectedPayment.label}
+            invoiceNumber={holdDetails.invoice_number}
+            memoText={memoText ?? `Invoice ${holdDetails.invoice_number}`}
+            holdExpiresAt={holdDetails.hold_expires_at}
+            timeZone={propertyTimezone}
+          />
           <p className="proof-note">
             Upload payment proof (screenshot or transaction ID) once sent so we can confirm your stay quickly.
           </p>

--- a/components/PaymentInstructions.tsx
+++ b/components/PaymentInstructions.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { PaymentMethod } from '@/lib/paymentOptions';
+
+interface PaymentInstructionsProps {
+  method: PaymentMethod;
+  methodLabel: string;
+  invoiceNumber: number | string;
+  memoText: string;
+  holdExpiresAt: string;
+  timeZone: string;
+}
+
+type CountdownState = {
+  msRemaining: number;
+  isExpired: boolean;
+  isValid: boolean;
+};
+
+const ZELLE_NAME = process.env.PAYMENT_ZELLE_NAME?.trim() || 'Stroman Properties';
+const ZELLE_EMAIL = process.env.PAYMENT_ZELLE_EMAIL?.trim() || 'payments@stromanproperties.com';
+const ZELLE_PHONE = process.env.PAYMENT_ZELLE_PHONE?.trim() || '(512) 555-0165';
+const VENMO_HANDLE = process.env.PAYMENT_VENMO_HANDLE?.trim() || '@StromanProperties';
+
+function calculateCountdown(expiresAt: string): CountdownState {
+  const timestamp = Date.parse(expiresAt);
+  if (Number.isNaN(timestamp)) {
+    return { msRemaining: 0, isExpired: true, isValid: false };
+  }
+  const diff = timestamp - Date.now();
+  return {
+    msRemaining: Math.max(0, diff),
+    isExpired: diff <= 0,
+    isValid: true,
+  };
+}
+
+function formatCountdown(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const padded = [hours, minutes, seconds].map((segment) => String(segment).padStart(2, '0'));
+  return `${padded[0]}:${padded[1]}:${padded[2]}`;
+}
+
+function formatDateTimeInZone(value: string, timeZone: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone,
+  }).format(date);
+}
+
+export default function PaymentInstructions({
+  method,
+  methodLabel,
+  invoiceNumber,
+  memoText,
+  holdExpiresAt,
+  timeZone,
+}: PaymentInstructionsProps) {
+  const [countdown, setCountdown] = useState<CountdownState>(() => calculateCountdown(holdExpiresAt));
+
+  useEffect(() => {
+    setCountdown(calculateCountdown(holdExpiresAt));
+    const timestamp = Date.parse(holdExpiresAt);
+    if (Number.isNaN(timestamp)) {
+      return undefined;
+    }
+    const interval = window.setInterval(() => {
+      setCountdown(calculateCountdown(holdExpiresAt));
+    }, 1000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [holdExpiresAt]);
+
+  const countdownLabel = useMemo(() => {
+    if (!countdown.isValid) {
+      return 'Countdown unavailable';
+    }
+    if (countdown.isExpired) {
+      return 'Hold expired';
+    }
+    return `Time remaining: ${formatCountdown(countdown.msRemaining)}`;
+  }, [countdown]);
+
+  const expiresDisplay = useMemo(
+    () => formatDateTimeInZone(holdExpiresAt, timeZone),
+    [holdExpiresAt, timeZone],
+  );
+
+  const countdownClassName = useMemo(
+    () => `hold-countdown${countdown.isValid && countdown.isExpired ? ' expired' : ''}`,
+    [countdown.isExpired, countdown.isValid],
+  );
+
+  let methodDetails: ReactNode;
+  if (method === 'zelle') {
+    methodDetails = (
+      <>
+        <p>Use your bank&apos;s Zelle transfer feature to send to the contact below.</p>
+        <ul className="payment-contact">
+          <li>
+            <span>Name</span>
+            <strong>{ZELLE_NAME}</strong>
+          </li>
+          <li>
+            <span>Email</span>
+            <strong>{ZELLE_EMAIL}</strong>
+          </li>
+          <li>
+            <span>Phone</span>
+            <strong>{ZELLE_PHONE}</strong>
+          </li>
+        </ul>
+        <p className="method-note">
+          Include the memo exactly so we can match your transfer quickly.
+        </p>
+      </>
+    );
+  } else {
+    methodDetails = (
+      <>
+        <p>Open Venmo and send to our business handle below.</p>
+        <ul className="payment-contact">
+          <li>
+            <span>Venmo handle</span>
+            <strong>{VENMO_HANDLE}</strong>
+          </li>
+        </ul>
+        <p className="method-note">Add your stay dates in the Venmo notes.</p>
+      </>
+    );
+  }
+
+  return (
+    <div className="payment-instructions">
+      <p>
+        Invoice <strong>{invoiceNumber}</strong> is reserved until <strong>{expiresDisplay}</strong>.
+      </p>
+      <p className={countdownClassName} role="status">
+        {countdownLabel}
+      </p>
+      <p>
+        Send the total via <strong>{methodLabel}</strong>.
+      </p>
+      {methodDetails}
+      <p className="payment-memo">
+        Memo: <strong>{memoText}</strong>
+      </p>
+    </div>
+  );
+}

--- a/lib/paymentOptions.ts
+++ b/lib/paymentOptions.ts
@@ -11,11 +11,14 @@ export interface PaymentOption {
   };
 }
 
+const ZELLE_EMAIL = process.env.PAYMENT_ZELLE_EMAIL?.trim() || 'payments@stromanproperties.com';
+const VENMO_HANDLE = process.env.PAYMENT_VENMO_HANDLE?.trim() || '@StromanProperties';
+
 export const PAYMENT_OPTIONS: PaymentOption[] = [
   {
     id: 'zelle',
     label: 'Zelle',
-    recipient: 'payments@stromanproperties.com',
+    recipient: ZELLE_EMAIL,
     instructions:
       'Send via your banking app to Stroman Properties. Include the memo so we can match your transfer quickly.',
     logo: {
@@ -26,9 +29,8 @@ export const PAYMENT_OPTIONS: PaymentOption[] = [
   {
     id: 'venmo',
     label: 'Venmo',
-    recipient: '@StromanProperties',
-    instructions:
-      'Open Venmo and send to @StromanProperties. Use the memo exactly and add your stay dates in the notes.',
+    recipient: VENMO_HANDLE,
+    instructions: `Open Venmo and send to ${VENMO_HANDLE}. Use the memo exactly and add your stay dates in the notes.`,
     logo: {
       src: '/images/payment-venmo.svg',
       alt: 'Venmo',

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    PAYMENT_ZELLE_NAME: process.env.PAYMENT_ZELLE_NAME,
+    PAYMENT_ZELLE_EMAIL: process.env.PAYMENT_ZELLE_EMAIL,
+    PAYMENT_ZELLE_PHONE: process.env.PAYMENT_ZELLE_PHONE,
+    PAYMENT_VENMO_HANDLE: process.env.PAYMENT_VENMO_HANDLE,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add a dedicated payment instructions panel that surfaces invoice, memo, countdown, and method-specific guidance
- wire the new instructions panel into the booking sidebar and refresh supporting styles
- expose payment contact environment variables for use on the client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d546685e08832892e02970a13d3bd5