### PR TITLE
Update booking payment logos

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -415,8 +415,9 @@ p, label {
 }
 
 .payment-option-image {
-  height: auto;
-  width: 96px;
+  height: 48px;
+  width: auto;
+  max-width: 120px;
 }
 
 .form-warning,

--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -271,8 +271,8 @@ export default function BookingSidebar({
                   <Image
                     src={option.logo.src}
                     alt=""
-                    width={96}
-                    height={40}
+                    width={option.logo.width}
+                    height={option.logo.height}
                     className="payment-option-image"
                   />
                 </span>

--- a/lib/paymentOptions.ts
+++ b/lib/paymentOptions.ts
@@ -8,6 +8,8 @@ export interface PaymentOption {
   logo: {
     src: string;
     alt: string;
+    width: number;
+    height: number;
   };
 }
 
@@ -22,8 +24,10 @@ export const PAYMENT_OPTIONS: PaymentOption[] = [
     instructions:
       'Send via your banking app to Stroman Properties. Include the memo so we can match your transfer quickly.',
     logo: {
-      src: '/images/payment-zelle.svg',
+      src: '/images/zelle-seeklogo.png',
       alt: 'Zelle',
+      width: 117,
+      height: 48,
     },
   },
   {
@@ -32,8 +36,10 @@ export const PAYMENT_OPTIONS: PaymentOption[] = [
     recipient: VENMO_HANDLE,
     instructions: `Open Venmo and send to ${VENMO_HANDLE}. Use the memo exactly and add your stay dates in the notes.`,
     logo: {
-      src: '/images/payment-venmo.svg',
+      src: '/images/venmo-seeklogo.png',
       alt: 'Venmo',
+      width: 64,
+      height: 48,
     },
   },
 ];


### PR DESCRIPTION
## Summary
- swap the Zelle and Venmo payment option assets to use the new PNG logos
- adjust booking sidebar payment option rendering to use per-logo dimensions
- tighten stylesheet rules so the new logos render at a consistent, compact height

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d54ddd93d883289fde764714e7596a