### PR TITLE
Adjust cleaning fee for single-night stays

### DIFF
--- a/app/api/bookings/hold/route.ts
+++ b/app/api/bookings/hold/route.ts
@@ -83,10 +83,14 @@ function computeTotals(start: Date, end: Date): HoldTotals {
   }
   const nightlyRate = Number(process.env.HOLD_NIGHTLY_RATE ?? '315');
   const cleaningFeeDefault = Number(process.env.HOLD_CLEANING_FEE ?? '200');
+  const singleNightCleaningFeeDefault = Number(
+    process.env.HOLD_SINGLE_NIGHT_CLEANING_FEE ?? '100',
+  );
   const taxRate = Number(process.env.HOLD_TAX_RATE ?? '0.1');
 
   const rateSubtotal = roundToCents(nightlyRate * nights);
-  const cleaningFee = roundToCents(cleaningFeeDefault);
+  const cleaningFeeBase = nights === 1 ? singleNightCleaningFeeDefault : cleaningFeeDefault;
+  const cleaningFee = roundToCents(cleaningFeeBase);
   const taxes = roundToCents((rateSubtotal + cleaningFee) * taxRate);
   const totalAmount = roundToCents(rateSubtotal + cleaningFee + taxes);
 

--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -108,7 +108,10 @@ export default function BookingSidebar({
       return null;
     }
     const nightlyTotal = nights * property.nightlyRate;
-    const cleaningFee = property.cleaningFee;
+    const cleaningFee =
+      nights === 1
+        ? property.singleNightCleaningFee ?? property.cleaningFee
+        : property.cleaningFee;
     const taxable = nightlyTotal + cleaningFee;
     const taxes = Number((taxable * property.taxRate).toFixed(2));
     const total = nightlyTotal + cleaningFee + taxes;
@@ -118,7 +121,13 @@ export default function BookingSidebar({
       taxes,
       total,
     };
-  }, [nights, property.cleaningFee, property.nightlyRate, property.taxRate]);
+  }, [
+    nights,
+    property.cleaningFee,
+    property.nightlyRate,
+    property.singleNightCleaningFee,
+    property.taxRate,
+  ]);
 
   const selectedPayment = useMemo(
     () => PAYMENT_OPTIONS.find((option) => option.id === (confirmedMethod ?? form.paymentMethod)),

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -20,6 +20,7 @@ export type Property = {
   bathrooms: number;
   nightlyRate: number;
   cleaningFee: number;
+  singleNightCleaningFee?: number;
   taxRate: number;
   icalUrl?: string;
 };
@@ -37,6 +38,7 @@ export const properties: Property[] = [
     bathrooms: 3.5,
     nightlyRate: 315,
     cleaningFee: 200,
+    singleNightCleaningFee: 100,
     taxRate: 0.1,
     rooms: [
       {


### PR DESCRIPTION
## Summary
- add support for a reduced single-night cleaning fee in the booking hold totals
- surface the same single-night cleaning fee in the booking sidebar estimates
- extend property metadata with the single-night cleaning fee value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d553e568c483288f194c236d171d6e