### PR TITLE
Fix booking hold request path and payload

### DIFF
--- a/components/BookingSidebar.tsx
+++ b/components/BookingSidebar.tsx
@@ -157,16 +157,16 @@ export default function BookingSidebar({
     setIsSubmitting(true);
     setError(null);
     try {
-      const response = await fetch('/api/bookings/holds', {
+      const response = await fetch('/api/bookings/hold', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           property_slug: property.slug,
+          full_name: form.fullName,
+          email: form.email,
+          phone: form.phone,
           check_in: checkIn.toISOString(),
           check_out: checkOut.toISOString(),
-          guest_name: form.fullName,
-          guest_email: form.email,
-          guest_phone: form.phone,
           payment_method: form.paymentMethod,
         }),
       });


### PR DESCRIPTION
## Summary
- update booking sidebar submission to use the correct /api/bookings/hold endpoint
- align request payload field names with the API expectations to avoid missing field errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d555a953f88328810e6f969911633c