### PR TITLE
Add owner admin dashboard for booking management

### DIFF
--- a/app/admin/bookings/_actions.ts
+++ b/app/admin/bookings/_actions.ts
@@ -1,0 +1,33 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { postAdminApi } from '@/lib/admin/http';
+
+async function performAction(path: string, invoiceNumber: string) {
+  await postAdminApi(path, { body: { invoice_number: invoiceNumber } });
+  revalidatePath('/admin/bookings');
+}
+
+export async function confirmBookingAction(formData: FormData) {
+  const invoiceNumber = formData.get('invoice_number');
+  if (typeof invoiceNumber !== 'string' || !invoiceNumber.trim()) {
+    throw new Error('Missing invoice number');
+  }
+  await performAction('/api/admin/bookings/verify', invoiceNumber.trim());
+}
+
+export async function expireBookingAction(formData: FormData) {
+  const invoiceNumber = formData.get('invoice_number');
+  if (typeof invoiceNumber !== 'string' || !invoiceNumber.trim()) {
+    throw new Error('Missing invoice number');
+  }
+  await performAction('/api/admin/bookings/expire', invoiceNumber.trim());
+}
+
+export async function cancelBookingAction(formData: FormData) {
+  const invoiceNumber = formData.get('invoice_number');
+  if (typeof invoiceNumber !== 'string' || !invoiceNumber.trim()) {
+    throw new Error('Missing invoice number');
+  }
+  await performAction('/api/admin/bookings/cancel', invoiceNumber.trim());
+}

--- a/app/admin/bookings/_components/BookingDetailDrawer.tsx
+++ b/app/admin/bookings/_components/BookingDetailDrawer.tsx
@@ -1,0 +1,61 @@
+import type { AdminBooking } from '@/lib/admin/bookings';
+
+interface BookingDetailDrawerProps {
+  booking: AdminBooking;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString();
+}
+
+export default function BookingDetailDrawer({ booking }: BookingDetailDrawerProps) {
+  return (
+    <details className="booking-detail">
+      <summary>View details</summary>
+      <div className="booking-detail__grid">
+        <div>
+          <h4>Guest</h4>
+          <p>{booking.guest?.fullName ?? '—'}</p>
+          <p>{booking.guest?.email ?? '—'}</p>
+          <p>{booking.guest?.phone ?? '—'}</p>
+        </div>
+        <div>
+          <h4>Payment</h4>
+          <p>Method: {booking.paymentMethod ?? '—'}</p>
+          <p>Status: {booking.payment?.status ?? '—'}</p>
+          <p>
+            Amount:{' '}
+            {typeof booking.payment?.amount === 'number'
+              ? `$${booking.payment.amount.toFixed(2)}`
+              : '—'}
+          </p>
+          <p>
+            Proof:{' '}
+            {booking.payment?.proofFileUrl ? (
+              <a href={booking.payment.proofFileUrl} target="_blank" rel="noreferrer noopener">
+                View file
+              </a>
+            ) : (
+              '—'
+            )}
+          </p>
+        </div>
+        <div>
+          <h4>Timestamps</h4>
+          <p>Hold expires: {formatDate(booking.holdExpiresAt)}</p>
+          <p>Created: {formatDate(booking.createdAt)}</p>
+          <p>Paid: {formatDate(booking.paidAt)}</p>
+          <p>Expired: {formatDate(booking.expiredAt)}</p>
+          <p>Cancelled: {formatDate(booking.canceledAt)}</p>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/app/admin/bookings/_components/BookingsTable.tsx
+++ b/app/admin/bookings/_components/BookingsTable.tsx
@@ -1,0 +1,150 @@
+import { PROPERTY_TIMEZONE } from '@/lib/stays';
+import type { AdminBooking, AdminBookingStatus } from '@/lib/admin/bookings';
+import BookingDetailDrawer from './BookingDetailDrawer';
+import Countdown from './Countdown';
+import StatusPill from './StatusPills';
+import {
+  cancelBookingAction,
+  confirmBookingAction,
+  expireBookingAction,
+} from '../_actions';
+
+interface BookingsTableProps {
+  bookings: AdminBooking[];
+  status: AdminBookingStatus;
+}
+
+function isHoldExpired(booking: AdminBooking): boolean {
+  if (!booking.holdExpiresAt) {
+    return false;
+  }
+  const date = new Date(booking.holdExpiresAt);
+  if (Number.isNaN(date.getTime())) {
+    return false;
+  }
+  return date.getTime() <= Date.now();
+}
+
+function formatDateRange(checkIn: string | null, checkOut: string | null): string {
+  if (!checkIn || !checkOut) {
+    return '—';
+  }
+  const arrival = new Date(checkIn);
+  const departure = new Date(checkOut);
+  if (Number.isNaN(arrival.getTime()) || Number.isNaN(departure.getTime())) {
+    return '—';
+  }
+  return `${arrival.toLocaleDateString()} → ${departure.toLocaleDateString()}`;
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString();
+}
+
+export default function BookingsTable({ bookings, status }: BookingsTableProps) {
+  if (!bookings.length) {
+    return <p className="admin-empty">No bookings found.</p>;
+  }
+
+  return (
+    <div className="admin-table-wrapper">
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>Invoice</th>
+            <th>Guest</th>
+            <th>Stay</th>
+            <th>Status</th>
+            <th>Expires In</th>
+            <th>Payment</th>
+            <th>Proof</th>
+            <th>Created</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {bookings.map((booking) => {
+            const holdExpired = isHoldExpired(booking);
+            const disableConfirm = status !== 'pending' || holdExpired;
+            const disableExpire = status !== 'pending' || holdExpired;
+            const disableCancel = status === 'expired';
+            return (
+              <tr key={booking.id} className={holdExpired ? 'admin-row--expired' : undefined}>
+                <td>
+                  <div className="admin-table__invoice">
+                    <strong>{booking.invoiceNumber}</strong>
+                    <BookingDetailDrawer booking={booking} />
+                  </div>
+                </td>
+                <td>
+                  <div>{booking.guest?.fullName ?? '—'}</div>
+                  <div className="admin-table__muted">{booking.guest?.email ?? '—'}</div>
+                  <div className="admin-table__muted">{booking.guest?.phone ?? '—'}</div>
+                </td>
+                <td>
+                  <div>{formatDateRange(booking.checkIn, booking.checkOut)}</div>
+                  <div className="admin-table__muted">
+                    {booking.nights ? `${booking.nights} night${booking.nights === 1 ? '' : 's'}` : '—'}
+                  </div>
+                </td>
+                <td>
+                  <StatusPill status={booking.status} />
+                </td>
+                <td>
+                  {status === 'pending' ? (
+                    <Countdown target={booking.holdExpiresAt} timezone={PROPERTY_TIMEZONE} />
+                  ) : (
+                    <span>{formatTimestamp(booking.holdExpiresAt)}</span>
+                  )}
+                </td>
+                <td>
+                  <div>{booking.paymentMethod ?? '—'}</div>
+                  <div className="admin-table__muted">{booking.payment?.status ?? '—'}</div>
+                </td>
+                <td>
+                  {booking.payment?.proofFileUrl ? (
+                    <a href={booking.payment.proofFileUrl} target="_blank" rel="noreferrer noopener">
+                      View proof
+                    </a>
+                  ) : (
+                    <span className="admin-table__muted">No file</span>
+                  )}
+                </td>
+                <td>{formatTimestamp(booking.createdAt)}</td>
+                <td>
+                  <div className="admin-actions">
+                    <form action={confirmBookingAction}>
+                      <input type="hidden" name="invoice_number" value={booking.invoiceNumber} />
+                      <button type="submit" disabled={disableConfirm}>
+                        Confirm
+                      </button>
+                    </form>
+                    <form action={expireBookingAction}>
+                      <input type="hidden" name="invoice_number" value={booking.invoiceNumber} />
+                      <button type="submit" disabled={disableExpire}>
+                        Expire
+                      </button>
+                    </form>
+                    <form action={cancelBookingAction}>
+                      <input type="hidden" name="invoice_number" value={booking.invoiceNumber} />
+                      <button type="submit" disabled={disableCancel}>
+                        Cancel
+                      </button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/admin/bookings/_components/Countdown.tsx
+++ b/app/admin/bookings/_components/Countdown.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface CountdownProps {
+  target: string | null;
+  timezone?: string;
+}
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) {
+    return 'Expired';
+  }
+  const totalSeconds = Math.floor(ms / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+  if (days) parts.push(`${days}d`);
+  if (hours || days) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+export default function Countdown({ target, timezone }: CountdownProps) {
+  const [remaining, setRemaining] = useState<string>(() => {
+    if (!target) return '—';
+    const targetDate = new Date(target);
+    if (Number.isNaN(targetDate.getTime())) {
+      return '—';
+    }
+    const diff = targetDate.getTime() - Date.now();
+    return formatDuration(diff);
+  });
+
+  useEffect(() => {
+    if (!target) {
+      setRemaining('—');
+      return;
+    }
+    const targetDate = new Date(target);
+    if (Number.isNaN(targetDate.getTime())) {
+      setRemaining('—');
+      return;
+    }
+    const update = () => {
+      const diff = targetDate.getTime() - Date.now();
+      setRemaining(formatDuration(diff));
+    };
+    update();
+    const timer = window.setInterval(update, 1000);
+    return () => window.clearInterval(timer);
+  }, [target]);
+
+  return <span className="countdown" data-timezone={timezone}>{remaining}</span>;
+}

--- a/app/admin/bookings/_components/StatusPills.tsx
+++ b/app/admin/bookings/_components/StatusPills.tsx
@@ -1,0 +1,34 @@
+interface StatusPillProps {
+  status: string | null;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  pending_hold: 'Pending',
+  paid: 'Confirmed',
+  expired: 'Expired',
+  canceled: 'Canceled',
+  cancelled: 'Canceled',
+};
+
+export default function StatusPill({ status }: StatusPillProps) {
+  if (!status) {
+    return <span className="status-pill status-pill--muted">Unknown</span>;
+  }
+  const normalized = status.toLowerCase();
+  const label = STATUS_LABELS[normalized] ?? status;
+
+  const classes = ['status-pill'];
+  if (normalized === 'pending_hold') {
+    classes.push('status-pill--pending');
+  } else if (normalized === 'paid') {
+    classes.push('status-pill--confirmed');
+  } else if (normalized === 'expired') {
+    classes.push('status-pill--expired');
+  } else if (normalized === 'canceled' || normalized === 'cancelled') {
+    classes.push('status-pill--canceled');
+  } else {
+    classes.push('status-pill--muted');
+  }
+
+  return <span className={classes.join(' ')}>{label}</span>;
+}

--- a/app/admin/bookings/_components/Toolbar.tsx
+++ b/app/admin/bookings/_components/Toolbar.tsx
@@ -1,0 +1,34 @@
+import type { ToolbarMeta } from '@/lib/admin/bookings';
+
+interface ToolbarProps {
+  meta: ToolbarMeta;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+export default function Toolbar({ meta }: ToolbarProps) {
+  return (
+    <section className="admin-toolbar" aria-label="Automation status">
+      <div>
+        <span className="admin-toolbar__label">Last expire sweep</span>
+        <strong>{formatDate(meta.lastSweepAt)}</strong>
+      </div>
+      <div>
+        <span className="admin-toolbar__label">Next sweep ETA</span>
+        <strong>{formatDate(meta.nextSweepEta)}</strong>
+      </div>
+    </section>
+  );
+}

--- a/app/admin/bookings/page.tsx
+++ b/app/admin/bookings/page.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link';
+import type { ToolbarMeta } from '@/lib/admin/bookings';
+import { fetchToolbarMeta, listBookingsByStatus } from '@/lib/admin/bookings';
+import { requireOwnerSession } from '@/lib/admin/auth';
+import BookingsTable from './_components/BookingsTable';
+import Toolbar from './_components/Toolbar';
+
+const TAB_OPTIONS = [
+  { label: 'Pending', value: 'pending' as const },
+  { label: 'Confirmed', value: 'confirmed' as const },
+  { label: 'Expired', value: 'expired' as const },
+];
+
+type TabValue = (typeof TAB_OPTIONS)[number]['value'];
+
+function isValidTab(value: string | undefined): value is TabValue {
+  return TAB_OPTIONS.some((tab) => tab.value === value);
+}
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+interface PageProps {
+  searchParams?: { [key: string]: string | undefined };
+}
+
+export default async function AdminBookingsPage({ searchParams }: PageProps) {
+  await requireOwnerSession();
+
+  const statusParam = searchParams?.status;
+  const activeTab: TabValue = isValidTab(statusParam) ? statusParam : 'pending';
+
+  const [bookingsResult, toolbarResult] = await Promise.allSettled([
+    listBookingsByStatus(activeTab),
+    fetchToolbarMeta(),
+  ]);
+
+  const bookings = bookingsResult.status === 'fulfilled' ? bookingsResult.value : [];
+  const toolbarMeta: ToolbarMeta =
+    toolbarResult.status === 'fulfilled'
+      ? toolbarResult.value
+      : { lastSweepAt: null, nextSweepEta: null };
+
+  const loadError =
+    bookingsResult.status === 'rejected'
+      ? bookingsResult.reason instanceof Error
+        ? bookingsResult.reason.message
+        : 'Unable to load bookings.'
+      : null;
+
+  return (
+    <div className="admin-bookings">
+      <header className="admin-header">
+        <h1>Booking Dashboard</h1>
+        <p className="admin-header__subtitle">
+          Review pending holds, confirm payments, and monitor automated expiration sweeps.
+        </p>
+      </header>
+
+      <Toolbar meta={toolbarMeta} />
+
+      <nav className="admin-tabs" aria-label="Booking status tabs">
+        {TAB_OPTIONS.map((tab) => {
+          const href = tab.value === 'pending' ? '/admin/bookings' : `/admin/bookings?status=${tab.value}`;
+          const isActive = tab.value === activeTab;
+          return (
+            <Link key={tab.value} href={href} className={isActive ? 'admin-tab admin-tab--active' : 'admin-tab'}>
+              {tab.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {loadError ? <p className="admin-error">{loadError}</p> : null}
+      <BookingsTable bookings={bookings} status={activeTab} />
+    </div>
+  );
+}

--- a/app/admin/login/LoginForm.tsx
+++ b/app/admin/login/LoginForm.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useFormState, useFormStatus } from 'react-dom';
+
+interface LoginState {
+  error?: string;
+}
+
+const INITIAL_STATE: LoginState = {};
+
+interface Props {
+  action: (state: LoginState, formData: FormData) => Promise<LoginState | void>;
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? 'Signing in…' : 'Sign in'}
+    </button>
+  );
+}
+
+export default function LoginForm({ action }: Props) {
+  const [state, formAction] = useFormState(action, INITIAL_STATE);
+
+  return (
+    <form className="admin-login__form" action={formAction}>
+      <label htmlFor="code">Admin Access Code</label>
+      <input id="code" name="code" type="password" placeholder="Enter code" required />
+      {state?.error ? <p className="admin-login__error">{state.error}</p> : null}
+      <SubmitButton />
+    </form>
+  );
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation';
+import LoginForm from './LoginForm';
+import {
+  createOwnerSessionCookie,
+  getOwnerDashboardSecret,
+  hasOwnerSession,
+} from '@/lib/admin/auth';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export default async function AdminLoginPage() {
+  if (await hasOwnerSession()) {
+    redirect('/admin/bookings');
+  }
+
+  async function authenticate(_: unknown, formData: FormData) {
+    'use server';
+
+    const code = formData.get('code');
+    if (typeof code !== 'string' || !code.trim()) {
+      return { error: 'Enter the access code.' };
+    }
+
+    const expected = getOwnerDashboardSecret();
+    if (code.trim() !== expected) {
+      return { error: 'Invalid access code.' };
+    }
+
+    await createOwnerSessionCookie();
+    redirect('/admin/bookings');
+  }
+
+  return (
+    <div className="admin-login">
+      <div className="admin-login__card">
+        <h1>Owner Dashboard</h1>
+        <p className="admin-login__subtitle">Enter the access code to view booking holds.</p>
+        <LoginForm action={authenticate} />
+      </div>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { hasOwnerSession } from '@/lib/admin/auth';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export default async function AdminIndexPage() {
+  if (await hasOwnerSession()) {
+    redirect('/admin/bookings');
+  }
+
+  redirect('/admin/login');
+}

--- a/app/admin/robots.ts
+++ b/app/admin/robots.ts
@@ -1,0 +1,10 @@
+export default function robots() {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        disallow: '/',
+      },
+    ],
+  };
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,322 @@ body {
     color: var(--color-text-primary);
 }
 
+.site-footer {
+  margin-top: 4rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 2rem 1.5rem;
+}
+
+.site-footer__inner {
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.site-footer__admin-link {
+  color: #bfdbfe;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.site-footer__admin-link:hover,
+.site-footer__admin-link:focus-visible {
+  color: #60a5fa;
+  text-decoration: underline;
+}
+
+.admin-login {
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.admin-login__card {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.15);
+  padding: 2.5rem 2rem;
+  max-width: 420px;
+  width: 100%;
+  text-align: center;
+}
+
+.admin-login__subtitle {
+  color: var(--color-text-secondary);
+  margin-bottom: 2rem;
+}
+
+.admin-login__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+
+.admin-login__form input {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+}
+
+.admin-login__form button {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.admin-login__form button:hover,
+.admin-login__form button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+}
+
+.admin-login__form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.admin-login__error {
+  margin: 0;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.admin-bookings {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 6rem;
+}
+
+.admin-header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.admin-header__subtitle {
+  color: var(--color-text-secondary);
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+
+.admin-tabs {
+  display: inline-flex;
+  gap: 0.75rem;
+  background: #e2e8f0;
+  padding: 0.5rem;
+  border-radius: 999px;
+  margin-bottom: 1.5rem;
+}
+
+.admin-tab {
+  padding: 0.5rem 1.5rem;
+  border-radius: 999px;
+  color: #1e3a8a;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.admin-tab--active {
+  background: #1e3a8a;
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(30, 58, 138, 0.25);
+}
+
+.admin-table-wrapper {
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table thead {
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 1rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.admin-table tbody tr:nth-child(odd) {
+  background: #f8fafc;
+}
+
+.admin-table tbody tr:nth-child(even) {
+  background: #ffffff;
+}
+
+.admin-row--expired {
+  opacity: 0.7;
+}
+
+.admin-table__invoice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-table__muted {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.admin-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-actions form {
+  display: inline;
+}
+
+.admin-actions button {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.admin-actions button:hover:not(:disabled),
+.admin-actions button:focus-visible:not(:disabled) {
+  background: #dbeafe;
+}
+
+.admin-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  background: #e2e8f0;
+  color: #1e3a8a;
+}
+
+.status-pill--pending {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-pill--confirmed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.status-pill--expired {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.status-pill--canceled {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.status-pill--muted {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.booking-detail {
+  font-size: 0.9rem;
+}
+
+.booking-detail__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.5rem;
+  background: #f8fafc;
+  border-radius: 12px;
+}
+
+.booking-detail__grid h4 {
+  margin-bottom: 0.5rem;
+}
+
+.admin-toolbar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+  background: linear-gradient(135deg, rgba(30, 58, 138, 0.1), rgba(37, 99, 235, 0.15));
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.admin-toolbar__label {
+  display: block;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  margin-bottom: 0.25rem;
+}
+
+.admin-empty {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 16px;
+  text-align: center;
+  color: var(--color-text-secondary);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+}
+
+.admin-error {
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+}
+
+.countdown {
+  font-family: 'Courier New', Courier, monospace;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .admin-actions {
+    flex-direction: row;
+  }
+
+  .admin-actions button {
+    width: auto;
+  }
+}
+
 nav.main-nav {
   display: flex;
   justify-content: space-between;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
+import Footer from '@/components/layout/Footer';
 
 export const dynamic = 'force-dynamic';
 
@@ -31,6 +32,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body>
         <main>{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="site-footer__inner">
+        <span className="site-footer__copy">© {new Date().getFullYear()} Stroman Properties</span>
+        <nav aria-label="Footer">
+          <Link href="/admin" className="site-footer__admin-link">
+            Admin
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -1,0 +1,128 @@
+import crypto from 'node:crypto';
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+const SESSION_COOKIE = 'admin_session';
+const SECRET_HEADER = 'x-owner-dashboard-secret';
+const LEGACY_SECRET_HEADER = 'x-admin-secret';
+
+function readSecret(): string | null {
+  const secret =
+    process.env.OWNER_DASHBOARD_SECRET?.trim() || process.env.ADMIN_API_SECRET?.trim() || null;
+  return secret && secret.length > 0 ? secret : null;
+}
+
+export function getOwnerDashboardSecret(): string {
+  const secret = readSecret();
+  if (!secret) {
+    throw new Error('OWNER_DASHBOARD_SECRET is not configured');
+  }
+  return secret;
+}
+
+function buildSessionToken(secret: string): string {
+  return crypto.createHash('sha256').update(secret).digest('hex');
+}
+
+function matchesSecret(value: string | null, secret: string): boolean {
+  if (!value) {
+    return false;
+  }
+  const providedBuffer = Buffer.from(value);
+  const secretBuffer = Buffer.from(secret);
+  if (providedBuffer.length !== secretBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(providedBuffer, secretBuffer);
+}
+
+export async function hasOwnerSession(): Promise<boolean> {
+  const secret = readSecret();
+  if (!secret) {
+    return false;
+  }
+
+  const headerStore = await headers();
+  const providedHeader =
+    headerStore.get(SECRET_HEADER)?.trim() ?? headerStore.get(LEGACY_SECRET_HEADER)?.trim();
+  if (matchesSecret(providedHeader ?? null, secret)) {
+    return true;
+  }
+
+  const cookieStore = await cookies();
+  const cookieValue = cookieStore.get(SESSION_COOKIE)?.value ?? null;
+  if (!cookieValue) {
+    return false;
+  }
+
+  const expected = buildSessionToken(secret);
+  return matchesSecret(cookieValue, expected);
+}
+
+export async function requireOwnerSession(): Promise<void> {
+  if (!(await hasOwnerSession())) {
+    redirect('/admin/login');
+  }
+}
+
+export async function createOwnerSessionCookie(): Promise<void> {
+  const secret = getOwnerDashboardSecret();
+  const cookieStore = await cookies();
+  cookieStore.set({
+    name: SESSION_COOKIE,
+    value: buildSessionToken(secret),
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 8, // 8 hours
+  });
+}
+
+export async function clearOwnerSessionCookie(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set({
+    name: SESSION_COOKIE,
+    value: '',
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+}
+
+export interface OwnerRequestContext {
+  actor: string;
+}
+
+function extractBearer(value: string | null): string | null {
+  if (!value) return null;
+  const match = value.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+export function requireOwner(request: Request): OwnerRequestContext {
+  const secret = getOwnerDashboardSecret();
+  const providedHeader =
+    request.headers.get(SECRET_HEADER)?.trim() ?? request.headers.get(LEGACY_SECRET_HEADER)?.trim();
+  const bearer = extractBearer(request.headers.get('authorization'));
+
+  const provided = providedHeader ?? bearer ?? null;
+  if (matchesSecret(provided, secret)) {
+    return { actor: 'admin-secret' };
+  }
+
+  const cookieHeader = request.headers.get('cookie') ?? '';
+  const expectedToken = buildSessionToken(secret);
+  const hasSession = cookieHeader
+    .split(';')
+    .map((cookie) => cookie.trim())
+    .some((cookie) => cookie === `${SESSION_COOKIE}=${expectedToken}`);
+
+  if (!hasSession) {
+    throw new Error('Unauthorized');
+  }
+
+  return { actor: 'admin-session' };
+}

--- a/lib/admin/bookings.ts
+++ b/lib/admin/bookings.ts
@@ -1,0 +1,268 @@
+import { createStayDetails } from '@/lib/stays';
+import { supabaseJson } from '@/lib/supabase/rest';
+
+export type AdminBookingStatus = 'pending' | 'confirmed' | 'expired';
+
+const STATUS_TO_DB: Record<AdminBookingStatus, string> = {
+  pending: 'pending_hold',
+  confirmed: 'paid',
+  expired: 'expired',
+};
+
+interface BookingRecord {
+  id: string;
+  invoice_number: string;
+  status: string;
+  hold_expires_at: string | null;
+  check_in: string | null;
+  check_out: string | null;
+  guest_id: string | null;
+  payment_method: string | null;
+  created_at: string | null;
+  paid_at: string | null;
+  expired_at: string | null;
+  canceled_at: string | null;
+  updated_at?: string | null;
+}
+
+interface GuestRecord {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+interface PaymentRecord {
+  id: string;
+  booking_id: string;
+  status: string | null;
+  processor: string | null;
+  payer_name: string | null;
+  reference: string | null;
+  note: string | null;
+  proof_file_url: string | null;
+  received_at: string | null;
+  verified_at: string | null;
+  amount: number | null;
+  created_at: string | null;
+}
+
+export interface AdminBookingGuest {
+  id: string;
+  fullName: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+export interface AdminBookingPayment {
+  id: string;
+  status: string | null;
+  processor: string | null;
+  payerName: string | null;
+  reference: string | null;
+  note: string | null;
+  proofFileUrl: string | null;
+  receivedAt: string | null;
+  verifiedAt: string | null;
+  amount: number | null;
+  createdAt: string | null;
+}
+
+export interface AdminBooking {
+  id: string;
+  invoiceNumber: string;
+  status: string;
+  holdExpiresAt: string | null;
+  checkIn: string | null;
+  checkOut: string | null;
+  paymentMethod: string | null;
+  createdAt: string | null;
+  paidAt: string | null;
+  expiredAt: string | null;
+  canceledAt: string | null;
+  nights: number | null;
+  guest: AdminBookingGuest | null;
+  payment: AdminBookingPayment | null;
+}
+
+export interface ToolbarMeta {
+  lastSweepAt: string | null;
+  nextSweepEta: string | null;
+}
+
+function encodeList(values: string[]): string {
+  return values.map((value) => encodeURIComponent(value)).join(',');
+}
+
+async function fetchBookings(status: AdminBookingStatus): Promise<BookingRecord[]> {
+  const dbStatus = STATUS_TO_DB[status];
+  const params = new URLSearchParams();
+  params.set('status', `eq.${dbStatus}`);
+  params.set(
+    'select',
+    [
+      'id',
+      'invoice_number',
+      'status',
+      'hold_expires_at',
+      'check_in',
+      'check_out',
+      'guest_id',
+      'payment_method',
+      'created_at',
+      'paid_at',
+      'expired_at',
+      'canceled_at',
+    ].join(','),
+  );
+  params.set('order', 'created_at.desc');
+  const path = `/bookings?${params.toString()}`;
+  const records = await supabaseJson<BookingRecord[]>(path);
+  return records ?? [];
+}
+
+async function fetchGuests(guestIds: string[]): Promise<Map<string, AdminBookingGuest>> {
+  if (!guestIds.length) {
+    return new Map();
+  }
+  const params = new URLSearchParams();
+  params.set('id', `in.(${encodeList(guestIds)})`);
+  params.set('select', 'id,full_name,email,phone');
+  const records = (await supabaseJson<GuestRecord[]>(`/guests?${params.toString()}`)) ?? [];
+  return new Map(
+    records.map((guest) => [
+      guest.id,
+      {
+        id: guest.id,
+        fullName: guest.full_name,
+        email: guest.email,
+        phone: guest.phone,
+      },
+    ]),
+  );
+}
+
+async function fetchPayments(bookingIds: string[]): Promise<Map<string, AdminBookingPayment>> {
+  if (!bookingIds.length) {
+    return new Map();
+  }
+  const params = new URLSearchParams();
+  params.set('booking_id', `in.(${encodeList(bookingIds)})`);
+  params.set(
+    'select',
+    [
+      'id',
+      'booking_id',
+      'status',
+      'processor',
+      'payer_name',
+      'reference',
+      'note',
+      'proof_file_url',
+      'received_at',
+      'verified_at',
+      'amount',
+      'created_at',
+    ].join(','),
+  );
+  params.set('order', 'created_at.desc');
+  const records = (await supabaseJson<PaymentRecord[]>(`/payments?${params.toString()}`)) ?? [];
+  const map = new Map<string, AdminBookingPayment>();
+  for (const record of records) {
+    if (map.has(record.booking_id)) {
+      continue;
+    }
+    map.set(record.booking_id, {
+      id: record.id,
+      status: record.status,
+      processor: record.processor,
+      payerName: record.payer_name,
+      reference: record.reference,
+      note: record.note,
+      proofFileUrl: record.proof_file_url,
+      receivedAt: record.received_at,
+      verifiedAt: record.verified_at,
+      amount: record.amount,
+      createdAt: record.created_at,
+    });
+  }
+  return map;
+}
+
+export async function listBookingsByStatus(status: AdminBookingStatus): Promise<AdminBooking[]> {
+  const bookings = await fetchBookings(status);
+  if (!bookings.length) {
+    return [];
+  }
+  const guestIds = Array.from(new Set(bookings.map((booking) => booking.guest_id).filter(Boolean))) as string[];
+  const bookingIds = bookings.map((booking) => booking.id);
+
+  const [guestMap, paymentMap] = await Promise.all([
+    fetchGuests(guestIds),
+    fetchPayments(bookingIds),
+  ]);
+
+  return bookings.map<AdminBooking>((booking) => {
+    const stayDetails =
+      booking.check_in && booking.check_out
+        ? createStayDetails(booking.check_in, booking.check_out)
+        : null;
+    return {
+      id: booking.id,
+      invoiceNumber: booking.invoice_number,
+      status: booking.status,
+      holdExpiresAt: booking.hold_expires_at,
+      checkIn: booking.check_in,
+      checkOut: booking.check_out,
+      paymentMethod: booking.payment_method,
+      createdAt: booking.created_at,
+      paidAt: booking.paid_at,
+      expiredAt: booking.expired_at,
+      canceledAt: booking.canceled_at,
+      nights: stayDetails?.nights ?? null,
+      guest: booking.guest_id ? guestMap.get(booking.guest_id) ?? null : null,
+      payment: paymentMap.get(booking.id) ?? null,
+    };
+  });
+}
+
+interface AuditRecord {
+  created_at: string | null;
+  actor: string | null;
+}
+
+const CRON_INTERVAL_MINUTES = 20;
+
+function computeNextSweep(lastSweepAt: string | null): string | null {
+  if (!lastSweepAt) {
+    return null;
+  }
+  const date = new Date(lastSweepAt);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  date.setMinutes(date.getMinutes() + CRON_INTERVAL_MINUTES);
+  return date.toISOString();
+}
+
+export async function fetchToolbarMeta(): Promise<ToolbarMeta> {
+  try {
+    const params = new URLSearchParams();
+    params.set('actor', 'eq.cron/expire-holds');
+    params.set('select', 'created_at,actor');
+    params.set('order', 'created_at.desc');
+    params.set('limit', '1');
+    const events = await supabaseJson<AuditRecord[]>(`/booking_audit_events?${params.toString()}`);
+    const lastSweepAt = events?.[0]?.created_at ?? null;
+    return {
+      lastSweepAt,
+      nextSweepEta: computeNextSweep(lastSweepAt),
+    };
+  } catch (error) {
+    console.error('Failed to load toolbar metadata', error);
+    return {
+      lastSweepAt: null,
+      nextSweepEta: null,
+    };
+  }
+}

--- a/lib/admin/http.ts
+++ b/lib/admin/http.ts
@@ -1,0 +1,33 @@
+import { getOwnerDashboardSecret } from './auth';
+
+function getApiBaseUrl(): string {
+  return (
+    process.env.INTERNAL_API_BASE_URL?.trim() ||
+    process.env.BOOKINGS_SITE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SITE_URL?.trim() ||
+    'http://localhost:3000'
+  );
+}
+
+interface PostOptions {
+  body?: unknown;
+}
+
+export async function postAdminApi(path: string, options: PostOptions = {}): Promise<void> {
+  const secret = getOwnerDashboardSecret();
+  const url = new URL(path, getApiBaseUrl());
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-owner-dashboard-secret': secret,
+    },
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(text || `Request to ${path} failed (${response.status})`);
+  }
+}

--- a/lib/stays.ts
+++ b/lib/stays.ts
@@ -138,3 +138,5 @@ export function formatStayRange(details: StayDetails): string {
 
   return `${startLabel} – ${endLabel}, ${yearLabel}`;
 }
+
+export const PROPERTY_TIMEZONE = DEFAULT_TIME_ZONE;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 30;
+
+interface RateLimitBucket {
+  count: number;
+  expiresAt: number;
+}
+
+const rateLimitBuckets = new Map<string, RateLimitBucket>();
+
+function trackRateLimit(request: NextRequest): NextResponse | null {
+  if (!request.nextUrl.pathname.startsWith('/api/admin/')) {
+    return null;
+  }
+
+  const now = Date.now();
+  const ip =
+    request.ip ?? request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  const bucket = rateLimitBuckets.get(ip);
+
+  if (!bucket || bucket.expiresAt < now) {
+    rateLimitBuckets.set(ip, { count: 1, expiresAt: now + RATE_LIMIT_WINDOW_MS });
+    return null;
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return new NextResponse(JSON.stringify({ error: 'Too many requests' }), {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    });
+  }
+
+  bucket.count += 1;
+  rateLimitBuckets.set(ip, bucket);
+  return null;
+}
+
+export function middleware(request: NextRequest) {
+  const rateLimitResponse = trackRateLimit(request);
+  if (rateLimitResponse) {
+    return rateLimitResponse;
+  }
+
+  const response = NextResponse.next();
+
+  if (request.nextUrl.pathname.startsWith('/admin')) {
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/api/admin/:path*'],
+};


### PR DESCRIPTION
## Summary
- add a global footer with an Admin link and build an access-code login flow for the owner dashboard
- implement a protected /admin/bookings UI with status tabs, booking detail drawer, countdown timers, and action buttons wired to the existing admin APIs
- introduce shared admin auth helpers, Supabase queries, and middleware-based noindex headers plus simple rate limiting for admin endpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57b30ead883289e1175cabae72edb