### PR TITLE
Adjust scroll buttons to clear footer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -433,7 +433,7 @@ nav.main-nav {
   width: 100%;
   max-width: var(--layout-max-width);
   transform: translate(-50%, 100%);
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease, bottom 0.2s ease;
 }
 
 .scroll-buttons .actions {

--- a/components/ScrollButtons.tsx
+++ b/components/ScrollButtons.tsx
@@ -15,22 +15,42 @@ export default function ScrollButtons({
 }: ScrollButtonsProps): ReactElement | null {
   const [visible, setVisible] = useState(false);
   const [enabled, setEnabled] = useState(false);
+  const [footerOffset, setFooterOffset] = useState(0);
 
   useEffect(() => {
-    const hero = document.querySelector('.landing-hero, .gallery-hero');
+    const hero = document.querySelector(
+      '.landing-hero, .gallery-hero',
+    ) as HTMLElement | null;
+    const footer = document.querySelector('.site-footer') as HTMLElement | null;
+
     if (!hero) {
       return;
     }
     setEnabled(true);
 
     const onScroll = () => {
-      const rect = (hero as HTMLElement).getBoundingClientRect();
+      const rect = hero.getBoundingClientRect();
       setVisible(rect.bottom <= 0);
+
+      if (footer) {
+        const footerRect = footer.getBoundingClientRect();
+        const overlap = Math.max(0, window.innerHeight - footerRect.top);
+        const desiredOffset = overlap > 0 ? overlap + 16 : 0;
+
+        setFooterOffset((current) =>
+          Math.abs(current - desiredOffset) > 0.5 ? desiredOffset : current,
+        );
+      }
     };
 
     window.addEventListener('scroll', onScroll);
+    window.addEventListener('resize', onScroll);
     onScroll();
-    return () => window.removeEventListener('scroll', onScroll);
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
   }, []);
 
   useEffect(() => {
@@ -46,7 +66,10 @@ export default function ScrollButtons({
   }
 
   return (
-    <div className={`scroll-buttons${visible ? ' visible' : ''}`}>
+    <div
+      className={`scroll-buttons${visible ? ' visible' : ''}`}
+      style={{ bottom: `${footerOffset}px` }}
+    >
       <span className="price">$315/night</span>
       <div className="actions">
         <Link href={`/properties/${slug}/book`} className="btn">


### PR DESCRIPTION
## Summary
- move the scroll buttons banner up when the footer enters the viewport so it stays visible above the footer
- add a bottom transition to the scroll buttons styles to keep the movement smooth

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de98f59d9c83288ef89fe72a833d50