### PR TITLE
feat: send contact emails with nodemailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ npm run dev
 ```
 
 Place property images under `public/images` (e.g. `public/images/kitchen`, `public/images/living-room`).
+
+### Environment variables
+
+Email messages submitted through the contact modal are delivered with Nodemailer. Add the following entries to your `.env` file (or the hosting provider’s environment variable settings):
+
+```
+SMTP_HOST=your-smtp-host
+SMTP_PORT=587
+SMTP_SECURE=false # set to true if your SMTP provider requires TLS on connect
+SMTP_USER=your-smtp-username
+SMTP_PASS=your-smtp-password-or-app-key
+SMTP_FROM_EMAIL=optional-from-address@example.com
+CONTACT_RECIPIENT_EMAIL=where-contact-messages-should-go@example.com
+```
+
+`SMTP_FROM_EMAIL` is optional—when omitted, the `SMTP_USER` value is used as the sender. `SMTP_PASS` is where you should place the App Key from your email provider if they support SMTP authentication via application keys.

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+
+import { sendContactEmail, type ContactFormPayload } from '@/lib/email';
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as Partial<ContactFormPayload>;
+
+  if (!body.email || !body.firstName || !body.lastName || !body.subject || !body.body) {
+    return NextResponse.json({ message: 'All fields are required.' }, { status: 400 });
+  }
+
+  try {
+    await sendContactEmail(body as ContactFormPayload);
+    return NextResponse.json({ message: 'Email sent successfully.' });
+  } catch (error) {
+    console.error('Failed to send contact email', error);
+    return NextResponse.json(
+      { message: 'Unable to send email. Please try again later.' },
+      { status: 500 },
+    );
+  }
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -1430,6 +1430,25 @@ button:hover,
   font-size: 1.05rem;
 }
 
+.modal button[disabled]:not(.close-btn) {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.modal .success-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1a7f37;
+  text-align: center;
+}
+
+.modal .error-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #c62828;
+  text-align: center;
+}
+
 .modal input,
 .modal textarea {
   width: 100%;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "next": "15.5.2",
+    "nodemailer": "^6.9.15",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },


### PR DESCRIPTION
## Summary
- add a Nodemailer-powered contact API endpoint and reusable mail helper
- update the contact modal to post to the new endpoint with inline status messaging and styles
- document the SMTP environment variables required for configuration

## Testing
- not run (npm install for nodemailer is blocked by the registry access restrictions in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de9829f82883289fedfdc43203f8ab