### PR TITLE
Improve admin login page branding

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,4 +1,6 @@
 import { redirect } from 'next/navigation';
+import Image from 'next/image';
+import Link from 'next/link';
 import LoginForm, { INITIAL_STATE, type LoginState } from './LoginForm';
 import {
   createOwnerSessionCookie,
@@ -38,9 +40,21 @@ export default async function AdminLoginPage() {
   return (
     <div className="admin-login">
       <div className="admin-login__card">
+        <div className="admin-login__logo">
+          <Image
+            src="/images/logo_transparent.png"
+            alt="Stroman Properties"
+            width={200}
+            height={52}
+            priority
+          />
+        </div>
         <h1>Owner Dashboard</h1>
         <p className="admin-login__subtitle">Enter the access code to view booking holds.</p>
         <LoginForm action={authenticate} />
+        <Link className="admin-login__back" href="/">
+          ← Back to site
+        </Link>
       </div>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,17 @@ main {
   text-align: center;
 }
 
+.admin-login__logo {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.admin-login__card h1 {
+  color: var(--color-primary);
+  margin-bottom: 0.75rem;
+}
+
 .admin-login__subtitle {
   color: var(--color-text-secondary);
   margin-bottom: 2rem;
@@ -135,6 +146,22 @@ main {
   margin: 0;
   color: #dc2626;
   font-weight: 600;
+}
+
+.admin-login__back {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 2rem;
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.admin-login__back:hover,
+.admin-login__back:focus-visible {
+  text-decoration: underline;
 }
 
 .admin-bookings {


### PR DESCRIPTION
## Summary
- add the Stroman Properties logo to the admin login card and align it with the site's primary color palette
- provide a back-to-site link and ensure the heading uses the brand primary color for readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dec00b32c0832886e54d9d2791af03