### PR TITLE
Switch admin booking status query to dashboard view

### DIFF
--- a/lib/admin/bookings.ts
+++ b/lib/admin/bookings.ts
@@ -116,7 +116,7 @@ async function fetchBookings(status: AdminBookingStatus): Promise<BookingRecord[
     ].join(','),
   );
   params.set('order', 'created_at.desc');
-  const path = `/bookings?${params.toString()}`;
+  const path = `/admin_bookings_dashboard?${params.toString()}`;
   const records = await supabaseJson<BookingRecord[]>(path);
   return records ?? [];
 }


### PR DESCRIPTION
## Summary
- update `listBookingsByStatus` to query the `admin_bookings_dashboard` view so `payment_method` comes from the admin view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec2b4ecac8328aef1494154424d41